### PR TITLE
fix for LOG-2159 Cluster Logging Pods in CrashLoopBackOff

### DIFF
--- a/fluentd-fix-LOG-2159.patch
+++ b/fluentd-fix-LOG-2159.patch
@@ -1,0 +1,22 @@
+diff --git a/fluentd/vendored_gem_src/fluentd/lib/fluent/plugin/parser_json.rb b/fluentd/vendored_gem_src/fluentd/lib/fluent/plugin/parser_json.rb
+index 7be12efa..ca8e67fb 100644
+--- a/fluentd/vendored_gem_src/fluentd/lib/fluent/plugin/parser_json.rb
++++ b/fluentd/vendored_gem_src/fluentd/lib/fluent/plugin/parser_json.rb
+@@ -54,12 +54,15 @@ module Fluent
+           Oj.default_options = Fluent::DEFAULT_OJ_OPTIONS
+           [Oj.method(:load), Oj::ParseError]
+         when :json then [JSON.method(:load), JSON::ParserError]
+-        when :yajl then [Yajl.method(:load), Yajl::ParseError]
++        #where is no oj parser, json parser falls back to yajl parser and it is throwing errors on certain platforms like Z-series. As a fix disabling it completely
++        #when :yajl then [Yajl.method(:load), Yajl::ParseError]
+         else
+           raise "BUG: unknown json parser specified: #{name}"
+         end
+       rescue LoadError => ex
+-        name = :yajl
++        #where is no oj parser, json parser falls back to yajl parser and it is throwing errors on certain platforms like Z-series. As a fix disabling it completely
++        #name = :yajl
++        name = :json
+         if log
+           if /\boj\z/ =~ ex.message
+             log.info "Oj is not installed, and failing back to Yajl for json parser"


### PR DESCRIPTION
### Description
patch for fixing fluentd issue on the use of yajl json parser. 

/cc @jcantrill 


### Links
- JIRA: https://issues.redhat.com/browse/LOG-2159

