### PR TITLE
LOG-2099: Add sequence number to log messages to fix entry order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ venv
 *.swo
 *.swp
 fluentd/lib/**/Gemfile.lock
+fluentd/1.7.4
+fluentd/1.14.5

--- a/fluentd/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/filter_viaq_data_model.rb
+++ b/fluentd/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/filter_viaq_data_model.rb
@@ -25,6 +25,7 @@ require 'fluent/match'
 
 require_relative 'filter_viaq_data_model_systemd'
 require_relative 'viaq_data_model_log_level_normalizer'
+require_relative 'viaq_data_model_openshift'
 
 begin
   ViaqMatchClass = Fluent::Match
@@ -54,6 +55,7 @@ module Fluent
   class ViaqDataModelFilter < Filter
     include ViaqDataModelFilterSystemd
     include ViaqDataModel::LogLevelNormalizer
+    include ViaqDataModel::OpenShift
 
     attr_reader :level_matcher
 
@@ -183,6 +185,7 @@ module Fluent
 
     def configure(conf)
       super
+      @openshift_sequence = 1
       @keep_fields = {}
       @default_keep_fields.each{|xx| @keep_fields[xx] = true}
       @extra_keep_fields.each{|xx| @keep_fields[xx] = true}

--- a/fluentd/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/viaq_data_model_openshift.rb
+++ b/fluentd/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/viaq_data_model_openshift.rb
@@ -1,0 +1,35 @@
+#
+# Fluentd ViaQ data model Filter Plugin
+#
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module ViaqDataModel
+
+    module OpenShift
+
+        MAX_SEQUENCE = 2**32 - 1
+
+        # add_openshift_data adds the data for the openshift block of the viaq data model
+        def add_openshift_data(record)
+            record['openshift'] = {} if record['openshift'].nil?
+            if record['openshift']['sequence'].nil?
+                record['openshift']['sequence'] = @openshift_sequence
+                @openshift_sequence += 1
+                @openshift_sequence = 1 if @openshift_sequence > MAX_SEQUENCE
+            end
+        end
+
+    end
+end

--- a/fluentd/lib/fluent-plugin-viaq_data_model/test/test_viaq_data_model_openshift.rb
+++ b/fluentd/lib/fluent-plugin-viaq_data_model/test/test_viaq_data_model_openshift.rb
@@ -1,0 +1,66 @@
+#
+# Fluentd Viaq Data Model Filter Plugin - Ensure records coming from Fluentd
+# use the correct Viaq data model formatting and fields.
+#
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#require_relative '../helper'
+require 'fluent/test'
+require 'test/unit/rr'
+
+require 'fluent/plugin/viaq_data_model_openshift'
+
+
+class ViaqDataModelFilterTest < Test::Unit::TestCase
+    include ViaqDataModel::OpenShift
+
+    setup do
+        @openshift_sequence = 1
+    end
+
+    sub_test_case '#add_openshift_data' do
+
+        test 'should add the openshift hash if it does not exist' do
+            assert_nothing_raised do
+                record = {"message" => "20210909T12:15:09 Warning Some Warning message"}
+                add_openshift_data(record)
+                assert_true(record['openshift']['sequence'] > 0, "Expected openshift hash to be created and the sequence number populated")
+            end
+        end
+        
+        test "should add the sequence number to the openshift hash if it does not exist" do
+            record = {"message" => "20210909T12:15:09 Warning Some Warning message", "openshift" => {}}
+            add_openshift_data(record)
+            assert_true(record['openshift']['sequence'] > 0, "Expected the sequence number populated")
+        end
+        test "should not modify the sequence number to the openshift hash if it does exist" do
+            recordOne = {"message" => "20210909T12:15:09 Warning Some Warning message", "openshift" => {}}
+            recordTwo = {"message" => "20210909T12:15:09 Warning Some Warning message", "openshift" => {}}
+            add_openshift_data(recordOne)
+            add_openshift_data(recordTwo)
+            assert_true(recordTwo['openshift']['sequence'] > recordOne['openshift']['sequence'], "Expected the sequence number to increment")
+        end
+        
+        test "should restart the sequence when it reaches max value" do
+            @openshift_sequence = MAX_SEQUENCE
+            recordOne = {"message" => "20210909T12:15:09 Warning Some Warning message", "openshift" => {}}
+            recordTwo = {"message" => "20210909T12:15:09 Warning Some Warning message", "openshift" => {}}
+            add_openshift_data(recordOne)
+            add_openshift_data(recordTwo)
+            assert_equal(1, recordTwo['openshift']['sequence'], "Exp. the sequence number to roll over")
+        end
+
+    end
+end


### PR DESCRIPTION
### Description
This PR:
* Updates the viaq data model to add a sequence number to address log entries where timestamp does not provide great enough resolution

### Links
* https://issues.redhat.com/browse/LOG-2099

cc @alanconway @vimalk78 


