### PR TITLE
LOG-2353: Update base images to be public

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,7 +1,7 @@
 ### This is a generated file from Dockerfile.in ###
 
 #@follow_tag(registry.redhat.io/ubi8/ruby-25:latest)
-FROM registry.ci.openshift.org/ocp/builder:ubi8.ruby.25
+FROM registry.access.redhat.com/ubi8/ruby-25
 ENV BUILD_VERSION=1.14.5
 ENV SOURCE_GIT_COMMIT=${CI_ORIGIN_AGGREGATED_LOGGING_UPSTREAM_COMMIT:-}
 ENV SOURCE_GIT_URL=${CI_ORIGIN_AGGREGATED_LOGGING_UPSTREAM_URL:-}

--- a/fluentd/origin-meta.yaml
+++ b/fluentd/origin-meta.yaml
@@ -1,3 +1,3 @@
 from:
 - source: registry.redhat.io/ubi8/ruby-25:(\d)-(?:[\.0-9\-]*)
-  target: registry.ci.openshift.org/ocp/builder:ubi8.ruby.25
+  target: registry.access.redhat.com/ubi8/ruby-25


### PR DESCRIPTION
### Description
This PR updates the Dockerfile to use public base images

/assign @alanconway 

cc @alanconway 

### Links
* https://issues.redhat.com/browse/LOG-2353