### PR TITLE
LOG-2291: Fix plugin to add sequence number

### DIFF
--- a/fluentd/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/filter_viaq_data_model.rb
+++ b/fluentd/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/filter_viaq_data_model.rb
@@ -499,6 +499,7 @@ module Fluent
       check_for_match_and_format(tag, time, record)
       add_pipeline_metadata(tag, time, record)
       handle_undefined_fields(tag, time, record)
+      add_openshift_data(record)
       # remove the field from record if it is not in the list of fields to keep and
       # it is empty
       record.delete_if{|k,v| !@keep_empty_fields_hash.key?(k) && (v.nil? || isempty(delempty(v)) || isempty(v))}

--- a/fluentd/lib/fluent-plugin-viaq_data_model/test/test_filter_viaq_data_model.rb
+++ b/fluentd/lib/fluent-plugin-viaq_data_model/test/test_filter_viaq_data_model.rb
@@ -145,6 +145,12 @@ class ViaqDataModelFilterTest < Test::Unit::TestCase
         d.emit_with_tag(tag, msg, @time)
       }.filtered.instance_variable_get(:@record_array)[0]
     end
+    test 'openshift data is added to the record' do
+      rec = emit_with_tag('tag', {'a'=>'b'})
+      assert_not_nil(rec['openshift'], 'Expect a hash added to root named "openshift"')
+      assert_not_nil(rec['openshift']['sequence'], 'Expect a key added to "openshift" named "sequence"')
+      assert_true(rec['openshift']['sequence'] > 0, 'Expect sequence number to be greater then zero')
+    end
     test 'see if undefined fields are kept at top level' do
       rec = emit_with_tag('tag', {'a'=>'b'})
       assert_equal('b', rec['a'])


### PR DESCRIPTION
### Description
This PR:
* Updates the viaq plugin to actually call the method to add sequence number to log records

/assign @vimalk78 

### Links
* https://issues.redhat.com/browse/LOG-2291