### PR TITLE
LOG-2220: Call counter increment with arg names

### DIFF
--- a/fluentd/lib/fluent-plugin-collected/lib/fluent/plugin/in_collected_tail_monitor.rb
+++ b/fluentd/lib/fluent-plugin-collected/lib/fluent/plugin/in_collected_tail_monitor.rb
@@ -94,11 +94,11 @@ module Fluent::Plugin
           if pe.read_inode == old_inode && pe.read_pos >= old_pos
             # Same file, has not been truncated since last we looked. Add the delta.
             @log.trace "delta bytes #{pe.read_pos}  #{old_pos}"
-            @metrics[:total_bytes_collected].increment(label, pe.read_pos)
+            @metrics[:total_bytes_collected].increment(labels: label, by: pe.read_pos)
           else
             # Changed file or truncated the existing file. Add the initial content.
             @log.trace "delta bytes #{pe.read_pos}"
-            @metrics[:total_bytes_collected].increment(label, pe.read_pos)
+            @metrics[:total_bytes_collected].increment(labels: label, by: pe.read_pos)
           end
         end
       end


### PR DESCRIPTION
### Description
This PR fixes a bug introduced by https://github.com/ViaQ/logging-fluentd/pull/21 for:

```
 2022-03-31 17:11:28 +0000 [error]: Unexpected error raised. Stopping the timer. title=:in_collected_tail_monitor error_class=ArgumentError error="wrong number of arguments (given 2, expected 0)"
  2022-03-31 17:11:28 +0000 [error]: /usr/local/share/gems/gems/prometheus-client-3.0.0/lib/prometheus/client/counter.rb:13:in `increment'
```
https://issues.redhat.com/browse/LOG-2220


/assign @syedriko 