### PR TITLE
LOG-2220: Fluentd collector not setting labels from /var/log/pods paths

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -38,7 +38,7 @@ Note the bundler version should match the version from the end of `Gemfile.lock`
 ```
 rvm gemset create fluentd
 rvm gemset use fluentd
-gem install bundler -v 1.17.3
+gem install bundler -v 2.2.33
 bundle install
 ```
 

--- a/fluentd/lib/fluent-plugin-collected/Gemfile.lock
+++ b/fluentd/lib/fluent-plugin-collected/Gemfile.lock
@@ -1,24 +1,24 @@
 PATH
   remote: .
   specs:
-    fluent-plugin-collected (1.0.0)
-      fluentd (>= 0.14.20, < 2)
-      prometheus-client (< 0.10)
+    fluent-plugin-collected (1.1.0)
+      fluentd (= 1.14.5)
+      prometheus-client (>= 2.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     cool.io (1.7.1)
-    fluent-plugin-prometheus (1.8.5)
+    fluent-plugin-prometheus (2.0.2)
       fluentd (>= 1.9.1, < 2)
-      prometheus-client (< 0.10)
-    fluentd (1.14.4)
+      prometheus-client (>= 2.1.0)
+    fluentd (1.14.5)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
       msgpack (>= 1.3.1, < 2.0.0)
-      serverengine (>= 2.2.2, < 3.0.0)
+      serverengine (>= 2.2.5, < 3.0.0)
       sigdump (~> 0.2.2)
       strptime (>= 0.2.4, < 1.0.0)
       tzinfo (>= 1.0, < 3.0)
@@ -26,11 +26,9 @@ GEM
       webrick (>= 1.4.2, < 1.8.0)
       yajl-ruby (~> 1.0)
     http_parser.rb (0.8.0)
-    msgpack (1.4.4)
+    msgpack (1.4.5)
     power_assert (2.0.1)
-    prometheus-client (0.9.0)
-      quantile (~> 0.2.1)
-    quantile (0.2.1)
+    prometheus-client (4.0.0)
     rake (10.5.0)
     rr (3.0.9)
     serverengine (2.2.5)
@@ -44,7 +42,7 @@ GEM
       test-unit (>= 2.5.2)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2021.5)
+    tzinfo-data (1.2022.1)
       tzinfo (>= 1.0.0)
     webrick (1.7.0)
     yajl-ruby (1.4.1)
@@ -54,7 +52,7 @@ PLATFORMS
 
 DEPENDENCIES
   fluent-plugin-collected!
-  fluent-plugin-prometheus (~> 1.8.5)
+  fluent-plugin-prometheus (~> 2.0.2)
   rake (~> 10.0)
   test-unit (~> 3.0)
   test-unit-rr (~> 1.0)

--- a/fluentd/lib/fluent-plugin-collected/fluent-plugin-collected.gemspec
+++ b/fluentd/lib/fluent-plugin-collected/fluent-plugin-collected.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-collected"
-  spec.version       = "1.0.0"
+  spec.version       = "1.1.0"
   spec.authors       = ["RedHat"]
   spec.email         = ["team-logging@redhat.com"]
   spec.homepage      = "https://github.com/openshift/origin-aggregated-logging/tree/master/fluentd/lib/fluent-plugin-collected"
@@ -13,12 +13,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fluentd", ">= 0.14.20", "< 2"
-  spec.add_dependency "prometheus-client", "< 0.10"
+  spec.add_dependency "fluentd", "=1.14.5"
+  spec.add_dependency "prometheus-client", ">=2.1.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_development_dependency "test-unit-rr", "~> 1.0"
-  spec.add_development_dependency "fluent-plugin-prometheus", "~> 1.8.5"
-
-
+  spec.add_development_dependency "fluent-plugin-prometheus", "~> 2.0.2"
 end

--- a/fluentd/lib/fluent-plugin-collected/lib/fluent/plugin/in_collected_tail_monitor.rb
+++ b/fluentd/lib/fluent-plugin-collected/lib/fluent/plugin/in_collected_tail_monitor.rb
@@ -9,28 +9,15 @@ module Fluent::Plugin
     include Fluent::Plugin::PrometheusLabelParser
 
     helpers :timer
-
-    #ideally interval must be rotatewait > 0 ? rotatewait/2 : 1.0
-    #and if interval >= rotate_wait we should log a warning.
-    #For rotatewait = 5 sec, interval can be set to 2 sec
-
-
     config_param :interval, :time, default: 2
     attr_reader :registry
 
-    MONITOR_IVARS = [
-      :tails,
-    ]
-
-    REGEX_VAR_LOG_PODS = Regexp.new('/var/log/pods/(?<namespace>[a-z0-9-]+)_(?<pod_name>[a-z0-9-]+)_(?<pod_uuid>[a-z0-9-]+)/(?<container_name>[a-z0-9-]+)/.*\.log$')
-    REGEX_VAR_LOG_CONTAINERS = Regexp.new('/var/log/containers/(?<pod_name>[a-z0-9-]+)_(?<namespace>[a-z0-9-]+)_(?<container_name>[a-z0-9-]+)-(?<docker_id>[a-z0-9]{64})\.log$')
-    REGEX_LOG_PATH=/(#{REGEX_VAR_LOG_PODS})|(#{REGEX_VAR_LOG_CONTAINERS})/
+    MONITOR_IVARS = [:tails].freeze
+    REGEX_LOG_PATH = Regexp.new('.*/(?<namespace>[a-z0-9-]+)_(?<pod_name>[a-z0-9-]+)_(?<pod_uuid>[a-z0-9-]+)/(?<container_name>[a-z0-9-]+)/.*\.log$').freeze
 
     def initialize
       super
       @registry = ::Prometheus::Client.registry
-      # As per k8 regex for container logfile symlink ref :
-      # https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/blob/master/lib/fluent/plugin/filter_kubernetes_metadata.rb#L56
     end
 
     def multi_workers_ready?
@@ -45,14 +32,14 @@ module Fluent::Plugin
       @base_labels = parse_labels_elements(conf)
       @base_labels.each do |key, value|
         unless value.is_a?(String)
-          raise Fluent::ConfigError, "record accessor syntax is not available in collected_tail_monitor"
+          raise Fluent::ConfigError, 'record accessor syntax is not available in collected_tail_monitor'
         end
+
         @base_labels[key] = expander.expand(value)
       end
 
       if defined?(Fluent::Plugin) && defined?(Fluent::Plugin::MonitorAgentInput)
-        # from v0.14.6
-        @monitor_agent = Fluent::Plugin::MonitorAgentInput.new
+        @monitor_agent = Fluent::Plugin::MonitorAgentInput.new # from v0.14.6
       else
         @monitor_agent = Fluent::MonitorAgentInput.new
       end
@@ -60,24 +47,17 @@ module Fluent::Plugin
 
     def start
       super
-
       @metrics = {
-        total_bytes_collected: get_counter(
-          :log_collected_bytes_total,
-          'Total bytes collected from file.'),
+        total_bytes_collected: get_counter(:log_collected_bytes_total, 'Total bytes collected from file.')
       }
       timer_execute(:in_collected_tail_monitor, @interval, &method(:update_monitor_info))
     end
 
-
     def update_monitor_info
-      opts = {
-        ivars: MONITOR_IVARS,
-      }
-
-     agent_info = @monitor_agent.plugins_info_all(opts).select do |info|
+      opts = { ivars: MONITOR_IVARS }
+      agent_info = @monitor_agent.plugins_info_all(opts).select do |info|
         info['type'] == 'tail'.freeze
-     end
+      end
       agent_info.each do |info|
         tails = info['instance_variables'][:tails]
         next if tails.nil?
@@ -87,6 +67,7 @@ module Fluent::Plugin
           # Very fragile implementation, borrowed from the standard prometheus_tail_monitor
           pe = watcher.instance_variable_get(:@pe)
           label = labels(info, watcher.path)
+          next if label.nil?
 
           # Compare pos/inode with the last time we saw this tail
           old_pos = pe.instance_variable_get(:@_old_pos) || 0.0
@@ -107,23 +88,25 @@ module Fluent::Plugin
     end
 
     def labels(plugin_info, path)
-      labels = { plugin_id: plugin_info['plugin_id'],
-                 type: plugin_info['type'],
-                 path: path }
-      # Extract labels from path, handle /var/log/pods and /var/log/containers formats.
       if (m = path.match(REGEX_LOG_PATH))
-        labels[:namespace] = m['namespace']
-        labels[:podname] = m['pod_name']
-        labels[:containername] = m['container_name']
+        @base_labels.merge(
+          {
+            plugin_id: plugin_info['plugin_id'],
+            type: plugin_info['type'],
+            namespace: m['namespace'],
+            podname: m['pod_name'],
+            poduuid: m['pod_uuid'],
+            containername: m['container_name']
+          }
+        )
       end
-      labels.merge!(@base_labels) # ! to avoid allocating another map
     end
 
     def get_counter(name, docstring)
       if @registry.exist?(name)
         @registry.get(name)
       else
-        @registry.counter(name, docstring: docstring, labels: [:hostname, :plugin_id, :type, :path, :namespace, :podname, :containername])
+        @registry.counter(name, docstring: docstring, labels: [:hostname, :plugin_id, :type, :namespace, :podname, :poduuid, :containername])
       end
     end
   end

--- a/fluentd/lib/fluent-plugin-collected/test/plugin/test_in_collected_tail_monitor.rb
+++ b/fluentd/lib/fluent-plugin-collected/test/plugin/test_in_collected_tail_monitor.rb
@@ -1,92 +1,160 @@
 require "test_helper"
 require "fluent/plugin/in_collected_tail_monitor"
+require 'net/http'
+require 'uri'
+require 'fileutils'
 
 class CollectedTailMonitorInputTest < Test::Unit::TestCase
   include Fluent
 
-  def setup
+  MONITOR_CONFIG = %(
+      @type collected_tail_monitor
+      <labels>
+        tag mytag
+        host example.com
+      </labels>
+   )
+
+  def setup()
     Fluent::Test.setup
   end
-
-  MONITOR_CONFIG = %[
-  @type tail
-     path /tmp/tmp.log, /var/log/containers/mypodname_mynamespace_mycontainername-34646d7fb38199129ab8d0e6f41833d26e1826cba92571100fd6c53904a5317e.log
-  
-  @type collected_tail_monitor
-    <labels>
-      tag mytag
-      host example.com
-    </labels>
-]
-
-  INVALID_MONITOR_CONFIG = %[
-  @type collected_tail_monitor
-
-  <labels>
-    host ${hostname}
-    foo bar
-    invalid_use1 $.foo.bar
-    invalid_use2 $[0][1]
-  </labels>
-  ]
 
   def create_driver(conf)
     Fluent::Test::Driver::Input.new(Fluent::Plugin::CollectedTailMonitorInput).configure(conf)
   end
 
   def test_configure
-    d = create_driver(MONITOR_CONFIG)
+    create_driver(MONITOR_CONFIG)
   end
 
-  def test_labels_applied_to_metrics
-    conf = MONITOR_CONFIG
-    puts "passing this #{conf}"
-    d = create_driver(conf)
-    beforerunlabels = d.instance.instance_variable_get(:@base_labels)
-    puts "before base labels set to ...#{beforerunlabels}"
-    d.run {
-    d.instance.update_monitor_info()
-    postrunlabels = d.instance.instance_variable_get(:@base_labels)
-    path = "/tmp/tmp.log"
-    mergedlabels  = d.instance.labels({"plugin_id" => "mypluginid", "type" => "input_plugin"}, path)
-    puts "with logfilepath as #{path} post merging base labels set to ...#{mergedlabels}"
-
-    # Test /var/log/containers format
-    path = "/var/log/containers/mypodname_mynamespace_mycontainername-34646d7fb38199129ab8d0e6f41833d26e1826cba92571100fd6c53904a5317e.log"
-    newmergedlabels  = d.instance.labels({"plugin_id" => "mypluginid", "type" => "input_plugin"}, path)
-    puts "with logfilepath as #{path} post merging base labels set to ...#{newmergedlabels}"
-
-    assert_equal('mynamespace',newmergedlabels[:namespace])
-    assert_equal('mycontainername',newmergedlabels[:containername])
-    assert_equal('mypodname',newmergedlabels[:podname])
-
-
-    # Test /var/log/pods format
-    path = "/var/log/pods/mynamespace2_mypodname2_05682f61-8a44-47af-ae0f-41ad3792e20a/mycontainername2/1.log"
-    newmergedlabels  = d.instance.labels({"plugin_id" => "mypluginid", "type" => "input_plugin"}, path)
-    puts "with logfilepath as #{path} post merging base labels set to ...#{newmergedlabels}"
-    assert_equal('mypluginid',newmergedlabels[:plugin_id])
-    assert_equal('mynamespace2',newmergedlabels[:namespace])
-    assert_equal('mycontainername2',newmergedlabels[:containername])
-    assert_equal('mypodname2',newmergedlabels[:podname])
-    }
- end
-
-  def test_invalid_configure
-      assert_raise(Fluent::ConfigError) {
-        d = create_driver(INVALID_MONITOR_CONFIG)
-      }
-  end
-
-  test 'emit' do
-    d = create_driver(MONITOR_CONFIG)
-    d.run(timeout: 0.5)
-
-    d.events.each do |tag, time, record|
-      assert_equal('input.test', tag)
-      assert_equal({'plugin_id' => 'fluentd','type' => 'tail'}, record)
-      assert(time.is_a?(Fluent::EventTime))
+  def test_labels
+    driver = create_driver(MONITOR_CONFIG)
+    driver.run do
+      driver.instance.update_monitor_info()
+      path = '/var/log/pods/mynamespace2_mypodname2_05682f61-8a44-47af-ae0f-41ad3792e20a/mycontainername2/1.log'
+      labels = driver.instance.labels({}, path)
+      assert_equal('mynamespace2', labels[:namespace])
+      assert_equal('mycontainername2', labels[:containername])
+      assert_equal('mypodname2', labels[:podname])
+      assert_equal('05682f61-8a44-47af-ae0f-41ad3792e20a', labels[:poduuid])
     end
   end
 
+  def test_regex
+    regex = Fluent::Plugin::CollectedTailMonitorInput::REGEX_LOG_PATH
+    path = '/var/log/pods/mynamespace2_mypodname2_05682f61-8a44-47af-ae0f-41ad3792e20a/mycontainername2/1.log'
+    assert_match(regex,path )
+    assert_equal(regex.match(path).to_a,
+                 [path,
+                  "mynamespace2",
+                  "mypodname2",
+                  "05682f61-8a44-47af-ae0f-41ad3792e20a",
+                  "mycontainername2"])
+    refute_match(regex, '/var/log/not-a-pod.log')
+  end
+
+  # Start a fluentd process and verify metrics are published for logs.
+  def test_functional
+    Dir.mktmpdir do |tmpdir|
+      conf_path = File.join(tmpdir, "fluent.conf")
+      File.write(conf_path, %(
+<source>
+  @type prometheus
+  bind 127.0.0.1
+  port 8888
+</source>
+
+<source>
+  @type prometheus_monitor
+  <labels>
+    hostname ${hostname}
+  </labels>
+</source>
+
+# excluding prometheus_tail_monitor
+# since it leaks namespace/pod info
+# via file paths
+
+# tail_monitor plugin which publishes log_collected_bytes_total
+<source>
+  @type collected_tail_monitor
+  <labels>
+    hostname ${hostname}
+  </labels>
+</source>
+
+# This is considered experimental by the repo
+<source>
+  @type prometheus_output_monitor
+  <labels>
+    hostname ${hostname}
+  </labels>
+</source>
+
+<source>
+  @type tail
+  path "#{tmpdir}/**/*.log"
+  tag kubernetes.*
+  <parse>
+      @type none
+  </parse>
+</source>
+
+<match **>
+  @type null
+</match>
+))
+      log_path = File.join(tmpdir, "fluent.log")
+      pod_log = File.join(tmpdir, 'mynamespace2_mypodname2_05682f61-8a44-47af-ae0f-41ad3792e20a/mycontainername2/1.log')
+      FileUtils.mkdir_p File.dirname(pod_log)
+      uri = URI.parse("http://localhost:8888/metrics")
+      spawn_fluentd(tmpdir, ["-c", conf_path, "-o", log_path ]) do
+        Timeout.timeout(10) do
+          File.write(pod_log, "hello\n")
+          response = Net::HTTP.get_response(uri)
+          assert_equal(response.code, '200')
+          assert_match(/.*TYPE log_collected_bytes_total counter.*/, response.body)
+          metrics = response.body.lines.grep(/^log_collected_bytes_total{.*/)
+          if !metrics.nil? && !metrics.empty?
+            assert_equal(metrics.size, 1)
+            metric = metrics[0]
+            assert_match(/hostname="#{Socket.gethostname}"/, metric)
+            assert_match(/namespace="mynamespace2"/,metric)
+            assert_match(/podname="mypodname2"/, metric)
+            assert_match(/poduuid="05682f61-8a44-47af-ae0f-41ad3792e20a"/, metric)
+            assert_match(/containername="mycontainername2"/, metric)
+            assert_match(/} 6.0$/, metric)
+          else
+            raise "retry"
+          end
+        rescue ::Test::Unit::AssertionFailedError
+          raise
+        rescue Exception => e
+          sleep 0.1
+          retry
+        end
+      rescue
+        if File.exist? log_path
+          puts "================ fluent.log"
+          puts File.read(log_path)
+        end
+        raise
+      end
+    end
+  end
+
+  def spawn_fluentd(dir, args)
+    cmdname = File.expand_path(File.dirname(__FILE__) + "../../../../../vendored_gem_src/fluentd/bin/fluentd")
+    gemfile = File.expand_path(File.dirname(__FILE__) + "../../../Gemfile")
+    env = { "BUNDLE_GEMFILE" => gemfile }
+    pid = spawn(env, "bundle", "exec", cmdname, *args, :chdir=>dir, )
+    begin
+      yield
+    ensure
+      Process.kill(:TERM, pid)
+      Timeout.timeout(10) do
+        Process.wait(pid)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Collector plugin was using very old version of prometheus-client that did not use keyword arguments, so arguments were treated as labels.  Updated the dependencies.

/cc @jcantrill