### PR TITLE
LOG-2523: Add flatten labels logic to Viaq plugin

### DIFF
--- a/fluentd/lib/fluent-plugin-viaq_data_model/Gemfile.lock
+++ b/fluentd/lib/fluent-plugin-viaq_data_model/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
     yajl-ruby (1.4.1)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/fluentd/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/filter_viaq_data_model.rb
+++ b/fluentd/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/filter_viaq_data_model.rb
@@ -24,6 +24,7 @@ require 'fluent/log'
 require 'fluent/match'
 
 require_relative 'filter_viaq_data_model_systemd'
+require_relative 'viaq_data_model_flatten_labels'
 require_relative 'viaq_data_model_elasticsearch_index_name'
 require_relative 'viaq_data_model_log_level_normalizer'
 require_relative 'viaq_data_model_openshift'
@@ -56,6 +57,7 @@ module Fluent
   class ViaqDataModelFilter < Filter
     include ViaqDataModelFilterSystemd
     include ViaqDataModel::ElasticsearchIndexName
+    include ViaqDataModel::FlattenLabels
     include ViaqDataModel::LogLevelNormalizer
     include ViaqDataModel::OpenShift
 
@@ -77,6 +79,14 @@ module Fluent
     # we want to preserve these empty messages
     desc 'List of fields to keep as empty fields - also added to extra_keep_fields'
     config_param :keep_empty_fields, default: ['message'] do |val|
+      val.split(',')
+    end
+
+    desc 'Enable functionality to flatten kubernetes.labels and remove them from the set except for exclusions'
+    config_param :enable_flatten_labels, :bool, default: false
+
+    desc 'Comma delimited list of labels to exclude from flattening'
+    config_param :flatten_exclusions, default: [] do |val|
       val.split(',')
     end
 
@@ -445,6 +455,7 @@ module Fluent
         end
       end
 
+      flatten_labels(record, @flatten_exclusions) if @enable_flatten_labels
       if !@elasticsearch_index_names.empty?
         add_elasticsearch_index_name_field(tag, time, record)
       elsif ENV['CDM_DEBUG']

--- a/fluentd/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/viaq_data_model_flatten_labels.rb
+++ b/fluentd/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/viaq_data_model_flatten_labels.rb
@@ -1,0 +1,39 @@
+#
+# Fluentd ViaQ data model Filter Plugin
+#
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module ViaqDataModel
+
+    module FlattenLabels
+
+        # flatten_labels makes kubernetes.labels into a key=value array
+        # and adds the result to the key 'flat_labels' key removing all
+        # but the exclusions from the original set
+        def flatten_labels(record, exclusions = [])
+            return record if record.nil? || record.dig('kubernetes','labels').nil?
+            kube = record['kubernetes']
+            kube['flat_labels'] = kube['labels'].map do |k,v| 
+                "#{k}=#{v}" unless exclusions.include?(k)
+            end.compact
+            kube['labels'].delete_if do |k,v|
+                !exclusions.include?(k)
+            end
+            kube.delete('labels') if kube['labels'].empty?
+            record
+        end
+
+    end
+end

--- a/fluentd/lib/fluent-plugin-viaq_data_model/test/test_viaq_data_model_flatten_labels.rb
+++ b/fluentd/lib/fluent-plugin-viaq_data_model/test/test_viaq_data_model_flatten_labels.rb
@@ -1,0 +1,52 @@
+#
+# Fluentd Viaq Data Model Filter Plugin - Ensure records coming from Fluentd
+# use the correct Viaq data model formatting and fields.
+#
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#require_relative '../helper'
+require 'fluent/test'
+require 'test/unit/rr'
+
+require 'fluent/plugin/viaq_data_model_flatten_labels'
+
+
+class ViaqDataModelFilterTest < Test::Unit::TestCase
+    include ViaqDataModel::FlattenLabels
+
+    setup do
+        @openshift_sequence = 1
+    end
+
+    sub_test_case '#flatten_labels' do
+
+        test 'should return the record if it is missing labels' do
+            record = {"foo" => "bar"}
+            assert_equal({"foo" => "bar"}, flatten_labels(record))
+        end
+
+        test "should convert the label set into an array of key=value" do
+            record = {"kubernetes" => { "labels" => { "foo" => "bar", "abc" => "123"}}}
+            exp = {"kubernetes" => { "flat_labels" => ["foo=bar", "abc=123"]}}
+            assert_equal(exp, flatten_labels(record))
+        end
+
+        test "should exclude the exclusions from flattening and remove the flattened" do
+            record = {"kubernetes" => { "labels" => { "foo" => "bar", "abc" => "123"}}}
+            exp = {"kubernetes" => { "labels" => {"abc" => "123"}, "flat_labels" => ["foo=bar"]}}
+            assert_equal(exp, flatten_labels(record, ['abc']))
+        end
+    end
+end


### PR DESCRIPTION
### Description
This PR:
* adds flatten label logic to the Viaq plugin
* Allows for excluding labels from flattening logic

### Links
* https://issues.redhat.com/browse/LOG-2523
