### PR TITLE
LOG-2682: Remove path from collected metrics

### DIFF
--- a/fluentd/lib/fluent-plugin-collected/lib/fluent/plugin/in_collected_tail_monitor.rb
+++ b/fluentd/lib/fluent-plugin-collected/lib/fluent/plugin/in_collected_tail_monitor.rb
@@ -120,7 +120,6 @@ module Fluent::Plugin
         @base_labels.merge(
         plugin_id: plugin_info["plugin_id"],
         type: plugin_info["type"],
-        path: path,
         namespace: namespace,
         podname: podname[0],
         containername: containername,
@@ -129,7 +128,6 @@ module Fluent::Plugin
         @base_labels.merge(
         plugin_id: plugin_info["plugin_id"],
         type: plugin_info["type"],
-        path: path,
         namespace: "notfound",
         podname: "notfound",
         containername: "notfound",


### PR DESCRIPTION
### Description
This PR:
* Removes path from collected log metrics to reduce pressure on prometheus server

### Links
* https://issues.redhat.com/browse/LOG-2682