### PR TITLE
LOG-2819: add ability to extract log level from message if it JSON valid string

### DIFF
--- a/fluentd/lib/fluent-plugin-viaq_data_model/test/test_viaq_data_model_log_level_normalizer.rb
+++ b/fluentd/lib/fluent-plugin-viaq_data_model/test/test_viaq_data_model_log_level_normalizer.rb
@@ -19,6 +19,7 @@
 #require_relative '../helper'
 require 'fluent/test'
 require 'test/unit/rr'
+require 'json'
 
 require 'fluent/plugin/viaq_data_model_log_level_normalizer'
 
@@ -55,6 +56,21 @@ class ViaqDataModelFilterTest < Test::Unit::TestCase
 
     sub_test_case '#extract_level_from_message' do
         
+        sub_test_case 'should return level from JSON formated message' do
+
+            test 'when the checks are nil' do
+                assert_equal("info", extract_level_from_message("{\"level\":\"info\", \"message\":\"test\"}", nil))
+            end
+
+            test 'when there is not valid JSON' do
+                assert_nil(extract_level_from_message("{123}", checks))
+            end
+
+            test 'when there valid JSON but has no level' do
+                assert_nil(extract_level_from_message("{\"info\":\"info\", \"message\":\"test\"}", checks))
+            end
+        end
+
         sub_test_case 'should return nil' do
 
             test 'when the checks are nil' do


### PR DESCRIPTION

Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
If log record doesn't contain `level` field, going to try to extract it from JSON valid message string if it is possible, otherwise fallback to regexp extraction 
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-2819
- Enhancement proposal:
