### PR TITLE
LOG-2819: Extract log level from structured if exist

### DIFF
--- a/fluentd/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/viaq_data_model_log_level_normalizer.rb
+++ b/fluentd/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/viaq_data_model_log_level_normalizer.rb
@@ -61,13 +61,14 @@ module ViaqDataModel
 
         # normalize_level! attempts to convert all level values into a common format
         # on the output side.  It optionally takes a block for further processing as needed
-        def normalize_level!(record, priority=nil)
+        def normalize_level!(record, priority=nil, dig_structured=false)
             
             level = record['level']
             # if the record already has a level field, and it looks like one of our well
             # known values, convert it to the canonical normalized form - otherwise,
             # preserve the value in string format
-            retlevel = nil 
+            retlevel = nil
+            struct_level = nil
             if !level.nil?
                 unless (retlevel = NORMAL_LEVELS[level]) ||
                         (level.respond_to?(:downcase) && (retlevel = NORMAL_LEVELS[level.downcase]))
@@ -76,6 +77,8 @@ module ViaqDataModel
             elsif !priority.nil?
               retlevel = PRIORITY_LEVELS[priority]
             end
+            struct_level = record.dig('structured','level') if dig_structured
+            retlevel = struct_level if !struct_level.nil?  
             if record['message'] && retlevel.nil? 
                 retlevel = extract_level_from_message(record['message'], @level_matcher)
             end

--- a/fluentd/lib/fluent-plugin-viaq_data_model/test/test_filter_viaq_data_model.rb
+++ b/fluentd/lib/fluent-plugin-viaq_data_model/test/test_filter_viaq_data_model.rb
@@ -301,6 +301,28 @@ class ViaqDataModelFilterTest < Test::Unit::TestCase
       assert_equal([88], rec['h']['i']['m'])
       assert_true(rec['h']['i']['n'])
     end
+
+    test 'when enabled extruct structured log level' do
+      rec = emit_with_tag('tag', {"structured" => { "level" => "info"}}, '
+        extract_structured_loglevel true
+      ')
+      assert_equal("info", rec['level'])
+      assert_equal({ "level" => "info"}, rec['structured'])
+    end
+    test 'when enabled extruct structured log level given root level should be replaced' do
+      rec = emit_with_tag('tag', {"level" => "debug", "structured" => { "level" => "info"}}, '
+        extract_structured_loglevel true
+      ')
+      assert_equal("info", rec['level'])
+      assert_equal({ "level" => "info"}, rec['structured'])
+    end
+    test 'when disabled extruct structured log level do nothing' do
+      rec = emit_with_tag('tag', {"structured" => { "level" => "info"}}, '
+        extract_structured_loglevel false
+      ')
+      assert_equal(nil, rec['level'])
+    end
+
   end
 
   sub_test_case 'formatters' do

--- a/fluentd/lib/fluent-plugin-viaq_data_model/test/test_viaq_data_model_log_level_normalizer.rb
+++ b/fluentd/lib/fluent-plugin-viaq_data_model/test/test_viaq_data_model_log_level_normalizer.rb
@@ -51,6 +51,33 @@ class ViaqDataModelFilterTest < Test::Unit::TestCase
                 assert_equal('warn', newrecord['level'])
             end
         end
+        
+        sub_test_case 'when take level from structured field' do
+
+            test "should add level field to the record" do
+                record = {"message" => "20210909T12:15:09 Warning Some Warning message", "structured" => { "level" => "info" }}
+                normalize_level!(record, nil, true)
+                assert_equal('info',record['level'])
+            end
+
+            test "should replace level from root with structured.level " do
+                record = {"level" => "error", "structured" => { "level" => "info" }}
+                normalize_level!(record, nil, true)
+                assert_equal('info',record['level'])
+            end
+
+            test "should keep log level as is if config" do
+                record = {"level" => "debug", "structured" => { "level" => "error" }}
+                normalize_level!(record, nil, false)
+                assert_equal('debug',record['level'])
+            end
+
+            test "should keep log level as if not structured.level field" do
+                record = {"level" => "info", "structured" => { "foo" => "error" }}
+                normalize_level!(record, nil, true)
+                assert_equal('info',record['level'])
+            end
+        end
     end
 
     sub_test_case '#extract_level_from_message' do


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
Add new Fluentd Filter Plugin for extracting log level from structured field if exits and checking is it match with log level from root field. Replace log level from root field if not match or set to default value.
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-2819
- Enhancement proposal:
