### PR TITLE
LOG-3112: Add openshift.cluster_id

### DIFF
--- a/fluentd/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/viaq_data_model_openshift.rb
+++ b/fluentd/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/viaq_data_model_openshift.rb
@@ -31,5 +31,13 @@ module ViaqDataModel
             end
         end
 
+        # add_cluster_id adds the value of the env variable 'OPENSHIFT_CLUSTER_ID' to the openshift hash
+        def add_cluster_id(record)
+            record['openshift'] = {} if record['openshift'].nil?
+            if (cluster_id = ENV['OPENSHIFT_CLUSTER_ID']) and !cluster_id.nil?
+                record['openshift']['cluster_id'] = cluster_id
+            end
+        end
+
     end
 end

--- a/fluentd/lib/fluent-plugin-viaq_data_model/test/test_viaq_data_model_openshift.rb
+++ b/fluentd/lib/fluent-plugin-viaq_data_model/test/test_viaq_data_model_openshift.rb
@@ -30,6 +30,32 @@ class ViaqDataModelFilterTest < Test::Unit::TestCase
         @openshift_sequence = 1
     end
 
+    sub_test_case '#add_cluster_id' do
+
+        test 'should add the cluster id when then env variable is present' do
+            begin
+              ENV['OPENSHIFT_CLUSTER_ID'] = 'abc123'
+              openshift = {"foo" => "bar"}
+              record = {"openshift" => openshift}
+              add_cluster_id(record)
+              assert_equal({"cluster_id" => "abc123", "foo" => "bar"}, record['openshift'])
+
+              record = {}
+              add_cluster_id(record)
+              assert_equal({"cluster_id" => "abc123"}, record['openshift'])
+            ensure
+                ENV.delete('OPENSHIFT_CLUSTER_ID')
+            end
+        end
+
+        test 'should silently proceed when then env variable is not present' do
+            record = {"openshift" => {"foo" => "bar"}}
+            add_cluster_id(record)
+            assert_equal(record,{"openshift" => {"foo" => "bar"}})
+        end
+
+    end
+
     sub_test_case '#add_openshift_data' do
 
         test 'should add the openshift hash if it does not exist' do


### PR DESCRIPTION
### Description
This PR:
* adds openshift.cluster_id if the proper environment variable is present


### Links
* https://issues.redhat.com/browse/LOG-3112
