### PR TITLE
LOG-3244: Fix variable name in Syslog ssl_context.rb

### DIFF
--- a/fluentd/lib/remote_syslog_sender/lib/remote_syslog_sender/ssl_context.rb
+++ b/fluentd/lib/remote_syslog_sender/lib/remote_syslog_sender/ssl_context.rb
@@ -61,7 +61,7 @@ module RemoteSyslogSender
         ssl_context.cert_store = store
       end
 
-      context.verify_mode = verify_mode if verify_mode
+      ssl_context.verify_mode = verify_mode if verify_mode
       # Verify certificate hostname if supported (ruby >= 2.4.0)
       ssl_context.verify_hostname = verify_hostname if ssl_context.respond_to?(:verify_hostname=)
 


### PR DESCRIPTION
### Description
In `ssl_context.rb`, If `verify_mode` is used, the function uses incorrect variable name `context`, whereas it should be `ssl_context`

This PR fixes it.


/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue: 
- JIRA: https://issues.redhat.com/browse/LOG-3244
- Enhancement proposal:
