### PR TITLE
LOG-3761: Fix pattern of regex for JS client side multiline exception

### DIFF
--- a/fluentd/fluent-plugin-detect-exceptions.source0001.patch
+++ b/fluentd/fluent-plugin-detect-exceptions.source0001.patch
@@ -1,16 +1,18 @@
 diff --git a/lib/fluent/plugin/exception_detector.rb b/lib/fluent/plugin/exception_detector.rb
-index d7c78b4..4fd62c6 100644
+index d7c78b4..3eb52b3 100644
 --- a/lib/fluent/plugin/exception_detector.rb
 +++ b/lib/fluent/plugin/exception_detector.rb
-@@ -53,7 +53,7 @@ module Fluent
+@@ -53,8 +53,9 @@ module Fluent
  
      JAVA_RULES = [
        rule([:start_state, :java_start_exception],
 -           /(?:Exception|Error|Throwable|V8 errors stack trace)[:\r\n]/,
-+           /(?:(Exception|Error|Throwable|V8 errors stack trace)[:\r\n]|java[x]?\..*(Exception|Error))/,
++           /(?:(Exception|Error|Throwable|V8 errors stack trace)[:\z\r\n]|java[x]?\..*(Exception|Error))/,
             :java_after_exception),
++      rule([:start_state, :java_start_exception], /Error\s*$/, :java_after_exception),
        rule(:java_after_exception, /^[\t ]*nested exception is:[\t ]*/,
             :java_start_exception),
+       rule(:java_after_exception, /^[\r\n]*$/, :java_after_exception),
 diff --git a/test/plugin/test_exception_detector.rb b/test/plugin/test_exception_detector.rb
 index f001d0e..4270c19 100644
 --- a/test/plugin/test_exception_detector.rb


### PR DESCRIPTION
### Description
This PR adds regex to matching some JS exception, where `Error` not ending with colon (`:`). 
For example: it should cover the case if JS Error fired without message. : 
`const error = new Error()
console.log(error.stack)`  
produce next trace:
```
Error
    at <anonymous>:1:15
```


<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3761
- Enhancement proposal:
