### PR TITLE
LOG-3781: Update rack to address fix CVE-2023-27530

### DIFF
--- a/fluentd/Gemfile.lock
+++ b/fluentd/Gemfile.lock
@@ -241,7 +241,7 @@ GEM
       protocol-hpack (~> 1.4)
       protocol-http (~> 0.18)
     public_suffix (4.0.7)
-    rack (3.0.4)
+    rack (3.0.4.2)
     rack-oauth2 (1.19.0)
       activesupport
       attr_required

--- a/fluentd/rh-manifest.txt
+++ b/fluentd/rh-manifest.txt
@@ -93,7 +93,7 @@ rubygem-nio4r 2.5.8 https://github.com/socketry/nio4r
 rubygem-oj 3.13.11 http://www.ohler.com/oj
 rubygem-prometheus-client 4.0.0 https://github.com/prometheus/client_ruby
 rubygem-public_suffix 4.0.7 https://simonecarletti.com/code/publicsuffix-ruby
-rubygem-rack 3.0.4 https://github.com/rack/rack
+rubygem-rack 3.0.4.2 https://github.com/rack/rack
 rubygem-rake 13.0.6 https://github.com/ruby/rake
 rubygem-recursive-open-struct 1.1.3 https://github.com/aetherknight/recursive-open-struct
 rubygem-rest-client 2.1.0 https://github.com/rest-client/rest-client

--- a/fluentd/vendored_gem_src/rack/CHANGELOG.md
+++ b/fluentd/vendored_gem_src/rack/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. For info on how to format all future additions to this file please reference [Keep A Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.0.4.1] - 2023-03-02
+
+- [CVE-2023-27530] Introduce multipart_total_part_limit to limit total parts
+
+## [3.0.4.1] - 2023-01-17
+
+- [CVE-2022-44571] Fix ReDoS vulnerability in multipart parser
+- [CVE-2022-44570] Fix ReDoS in Rack::Utils.get_byte_ranges
+- [CVE-2022-44572] Forbid control characters in attributes (also ReDoS)
+
 ## [3.0.4] - 2022-01-17
 
 - `Rack::Request#POST` should consistently raise errors. Cache errors that occur when invoking `Rack::Request#POST` so they can be raised again later. ([#2010](https://github.com/rack/rack/pull/2010), [@ioquatix])

--- a/fluentd/vendored_gem_src/rack/README.md
+++ b/fluentd/vendored_gem_src/rack/README.md
@@ -186,19 +186,35 @@ but this query string would not be allowed:
 
 Limiting the depth prevents a possible stack overflow when parsing parameters.
 
-### `multipart_part_limit`
+### `multipart_file_limit`
 
 ```ruby
-Rack::Utils.multipart_part_limit = 128 # default
+Rack::Utils.multipart_file_limit = 128 # default
 ```
 
-The maximum number of parts a request can contain. Accepting too many parts can
-lead to the server running out of file handles.
+The maximum number of parts with a filename a request can contain. Accepting
+too many parts can lead to the server running out of file handles.
 
 The default is 128, which means that a single request can't upload more than 128
 files at once. Set to 0 for no limit.
 
-Can also be set via the `RACK_MULTIPART_PART_LIMIT` environment variable.
+Can also be set via the `RACK_MULTIPART_FILE_LIMIT` environment variable.
+
+(This is also aliased as `multipart_part_limit` and `RACK_MULTIPART_PART_LIMIT` for compatibility)
+
+
+### `multipart_total_part_limit`
+
+The maximum total number of parts a request can contain of any type, including
+both file and non-file form fields.
+
+The default is 4096, which means that a single request can't contain more than
+4096 parts.
+
+Set to 0 for no limit.
+
+Can also be set via the `RACK_MULTIPART_TOTAL_PART_LIMIT` environment variable.
+
 
 ## Changelog
 

--- a/fluentd/vendored_gem_src/rack/lib/rack/multipart/parser.rb
+++ b/fluentd/vendored_gem_src/rack/lib/rack/multipart/parser.rb
@@ -8,6 +8,8 @@ module Rack
   module Multipart
     class MultipartPartLimitError < Errno::EMFILE; end
 
+    class MultipartTotalPartLimitError < StandardError; end
+
     # Use specific error class when parsing multipart request
     # that ends early.
     class EmptyContentError < ::EOFError; end
@@ -23,10 +25,10 @@ module Rack
     VALUE = /"(?:\\"|[^"])*"|#{TOKEN}/
     BROKEN = /^#{CONDISP}.*;\s*filename=(#{VALUE})/i
     MULTIPART_CONTENT_TYPE = /Content-Type: (.*)#{EOL}/ni
-    MULTIPART_CONTENT_DISPOSITION = /Content-Disposition:.*;\s*name=(#{VALUE})/ni
+    MULTIPART_CONTENT_DISPOSITION = /Content-Disposition:[^:]*;\s*name=(#{VALUE})/ni
     MULTIPART_CONTENT_ID = /Content-ID:\s*([^#{EOL}]*)/ni
     # Updated definitions from RFC 2231
-    ATTRIBUTE_CHAR = %r{[^ \t\v\n\r)(><@,;:\\"/\[\]?='*%]}
+    ATTRIBUTE_CHAR = %r{[^ \x00-\x1f\x7f)(><@,;:\\"/\[\]?='*%]}
     ATTRIBUTE = /#{ATTRIBUTE_CHAR}+/
     SECTION = /\*[0-9]+/
     REGULAR_PARAMETER_NAME = /#{ATTRIBUTE}#{SECTION}?/
@@ -166,7 +168,7 @@ module Rack
 
           @mime_parts[mime_index] = klass.new(body, head, filename, content_type, name)
 
-          check_open_files
+          check_part_limits
         end
 
         def on_mime_body(mime_index, content)
@@ -178,11 +180,21 @@ module Rack
 
         private
 
-        def check_open_files
-          if Utils.multipart_part_limit > 0
-            if @open_files >= Utils.multipart_part_limit
+        def check_part_limits
+          file_limit = Utils.multipart_file_limit
+          part_limit = Utils.multipart_total_part_limit
+
+          if file_limit && file_limit > 0
+            if @open_files >= file_limit
               @mime_parts.each(&:close)
               raise MultipartPartLimitError, 'Maximum file multiparts in content reached'
+            end
+          end
+
+          if part_limit && part_limit > 0
+            if @mime_parts.size >= part_limit
+              @mime_parts.each(&:close)
+              raise MultipartTotalPartLimitError, 'Maximum total multiparts in content reached'
             end
           end
         end

--- a/fluentd/vendored_gem_src/rack/lib/rack/version.rb
+++ b/fluentd/vendored_gem_src/rack/lib/rack/version.rb
@@ -25,7 +25,7 @@ module Rack
     VERSION
   end
 
-  RELEASE = "3.0.4"
+  RELEASE = "3.0.4.2"
 
   # Return the Rack release as a dotted string.
   def self.release

--- a/fluentd/vendored_gem_src/rack/rack.gemspec
+++ b/fluentd/vendored_gem_src/rack/rack.gemspec
@@ -1,15 +1,15 @@
 # -*- encoding: utf-8 -*-
-# stub: rack 3.0.4 ruby lib
+# stub: rack 3.0.4.2 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "rack".freeze
-  s.version = "3.0.4"
+  s.version = "3.0.4.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "bug_tracker_uri" => "https://github.com/rack/rack/issues", "changelog_uri" => "https://github.com/rack/rack/blob/main/CHANGELOG.md", "documentation_uri" => "https://rubydoc.info/github/rack/rack", "source_code_uri" => "https://github.com/rack/rack" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Leah Neukirchen".freeze]
-  s.date = "2023-01-16"
+  s.date = "2023-03-02"
   s.description = "Rack provides a minimal, modular and adaptable interface for developing\nweb applications in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible, it unifies and distills the API for web\nservers, web frameworks, and software in between (the so-called\nmiddleware) into a single method call.\n".freeze
   s.email = "leah@vuxu.org".freeze
   s.extra_rdoc_files = ["README.md".freeze, "CHANGELOG.md".freeze, "CONTRIBUTING.md".freeze]


### PR DESCRIPTION
### Description
This PR update rack version to the `3.0.4.2` to address fix `CVE 2023-27530` ([ruby-advisory-db/CVE-2023-27530](https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rack/CVE-2023-27530.yml))
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3781
- Enhancement proposal:
