### PR TITLE
LOG-3815: Update rack to address fix CVE-2023-27539

### DIFF
--- a/fluentd/Gemfile.lock
+++ b/fluentd/Gemfile.lock
@@ -241,7 +241,7 @@ GEM
       protocol-hpack (~> 1.4)
       protocol-http (~> 0.18)
     public_suffix (4.0.7)
-    rack (3.0.4.2)
+    rack (3.0.6.1)
     rack-oauth2 (1.19.0)
       activesupport
       attr_required


### PR DESCRIPTION
### Description
This PR update rack version to the `3.0.6.1` to address fix `CVE 2023-27539` ([ruby-advisory-db/CVE-2023-27539](https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rack/CVE-2023-27539.yml))
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3815
- Enhancement proposal:
