### PR TITLE
LOG-3471: Upgrade to ruby 3.1 on ubi9

### DIFF
--- a/Dockerfile.unit
+++ b/Dockerfile.unit
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ruby-27
+FROM registry.access.redhat.com/ubi9/ruby-31
 
 ENV FLUENTD_VERSION=1.14.6 \
     WORKDIR=/tmp/fluentd/lib

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,11 @@ install-gems:
 update-libs-for-fluentd:
 	FLUENTD_VERSION=$(FLUENTD_VERSION) ; \
 	for d in $$(ls fluentd/lib); do pushd fluentd/lib/$$d ; \
-		sed -i "s/add_runtime_dependency.*\"fluentd\".*/add_runtime_dependency \"fluentd\", \"=$$FLUENTD_VERSION\"/" $$(ls *.gemspec) ; \
+		grep fluentd $$(ls *.gemspec) ; \
+		if [ "$$?" -eq "0" ] ; then  \
+		sed -i "s/add.*dependency.*\"fluentd\".*/add_runtime_dependency \"fluentd\", \"=$$FLUENTD_VERSION\"/" $$(ls *.gemspec) ; \
 		bundle update fluentd --conservative --bundler ; \
+		fi ; \
 		popd ; \
 	done
 .PHONY: update-libs-for-fluentd

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,13 +1,13 @@
 ### This is a generated file from Dockerfile.in ###
 #@follow_tag(registry.redhat.io/ubi8/ruby-27:latest)
-FROM registry.access.redhat.com/ubi8/ruby-27 AS builder
+FROM registry.access.redhat.com/ubi9/ruby-31 AS builder
 
 ENV REMOTE_SOURCES=${REMOTE_SOURCES:-"."}
 ENV REMOTE_SOURCES_DIR=${REMOTE_SOURCES_DIR:-"."}
 
 USER 0
 RUN : 'removed yum-config-manager' \
- &&   BUILD_PKGS="make gcc-c++ libffi-devel autoconf automake libtool m4 redhat-rpm-config" \
+ &&   BUILD_PKGS="make gcc-c++ libffi-devel autoconf automake libtool m4 redhat-rpm-config libxml2-devel" \
  &&   RUNTIME_PKGS="hostname bc iproute" \
  &&   yum install -y --setopt=tsflags=nodocs $BUILD_PKGS $RUNTIME_PKGS \
  &&   rpm -V $BUILD_PKGS \
@@ -17,25 +17,17 @@ RUN : 'removed yum-config-manager' \
 
 ENV upstream_code=${upstream_code:-"."} \
     HOME=/opt/app-root/src 
-COPY ${upstream_code}/jemalloc/ /tmp/jemalloc/
-RUN pushd /tmp/jemalloc && \
-        EXTRA_CFLAGS="$( rpm --eval '%{optflags}' )" ./autogen.sh && \
-        make install_lib_shared install_bin && \
-        cp COPYING /tmp/COPYING.jemalloc && \
-    popd
-
-COPY ${upstream_code}/source.jemalloc /source.jemalloc
-RUN bash -c '. /source.jemalloc; echo jemalloc $JEMALLOC_VER >> /contents'
 
 COPY ${upstream_code}/lib  ${HOME}/lib
 COPY ${upstream_code}/Gemfile* ${HOME}/
 WORKDIR ${HOME}
 
-RUN for d in $(ls lib); do pushd lib/$d; rm *.gem; gem build *.gemspec; gem install -N --install-dir /usr/share/gems --bindir /usr/bin *.gem; popd; done && \
- CONFIGURE_ARGS="--with-cflags='$( rpm --eval %optflags )'" bundle install
+RUN CONFIGURE_ARGS="--with-cflags='$( rpm --eval %optflags )'" bundle install && \
+    for d in $(ls lib); do pushd lib/$d; gem build --force -V *.gemspec; \ 
+    gem install -N -minimal-deps --local --force --install-dir /usr/share/gems --bindir /usr/bin *.gem; popd; done
 
 #@follow_tag(registry.redhat.io/ubi8/ruby-27:latest)
-FROM registry.access.redhat.com/ubi8/ruby-27 AS runtime
+FROM registry.access.redhat.com/ubi9/ruby-31 AS runtime
 
 ENV REMOTE_SOURCES=${REMOTE_SOURCES:-"."}
 ENV upstream_code=${upstream_code:-"."}
@@ -58,7 +50,7 @@ ENV DATA_VERSION=$DATA_VERSION_VALUE \
     container=$CONTAINER_VALUE
 
 USER 0
-RUN RUNTIME_PKGS="hostname bc iproute" \
+RUN RUNTIME_PKGS="hostname bc iproute libxml2" \
  &&   yum install -y --setopt=tsflags=nodocs $RUNTIME_PKGS \
  &&   rpm -V $RUNTIME_PKGS \
  &&   yum clean all
@@ -67,10 +59,6 @@ RUN mkdir -p /etc/fluent/plugin
 
 COPY --from=builder /usr/bin/fluentd /usr/local/bin
 COPY --from=builder /usr/bin/fluent-cat /usr/local/bin
-COPY --from=builder /usr/local/lib/libjemalloc* /usr/local/lib
-COPY --from=builder /usr/local/bin/jemalloc-config /usr/local/bin
-COPY --from=builder /usr/local/bin/jemalloc.sh /usr/local/bin
-COPY --from=builder /usr/local/bin/jeprof /usr/local/bin
 
 COPY --from=builder /usr/share/gems /usr/share/gems
 COPY --from=builder /usr/lib64/gems/ruby /usr/lib64/gems/ruby

--- a/fluentd/Dockerfile.in
+++ b/fluentd/Dockerfile.in
@@ -6,7 +6,7 @@ ENV REMOTE_SOURCES_DIR=${REMOTE_SOURCES_DIR:-"."}
 
 USER 0
 RUN : 'removed yum-config-manager' \
- &&   BUILD_PKGS="make gcc-c++ libffi-devel autoconf automake libtool m4 redhat-rpm-config" \
+ &&   BUILD_PKGS="make gcc-c++ libffi-devel autoconf automake libtool m4 redhat-rpm-config libxml2-devel" \
  &&   RUNTIME_PKGS="hostname bc iproute" \
  &&   yum install -y --setopt=tsflags=nodocs $BUILD_PKGS $RUNTIME_PKGS \
  &&   rpm -V $BUILD_PKGS \
@@ -19,22 +19,14 @@ ENV upstream_code=$REMOTE_SOURCES/fluentd/app/fluentd
 
 ENV upstream_code=${upstream_code:-"."} \
     HOME=/opt/app-root/src 
-COPY ${upstream_code}/jemalloc/ /tmp/jemalloc/
-RUN pushd /tmp/jemalloc && \
-        EXTRA_CFLAGS="$( rpm --eval '%{optflags}' )" ./autogen.sh && \
-        make install_lib_shared install_bin && \
-        cp COPYING /tmp/COPYING.jemalloc && \
-    popd
-
-COPY ${upstream_code}/source.jemalloc /source.jemalloc
-RUN bash -c '. /source.jemalloc; echo jemalloc $JEMALLOC_VER >> /contents'
 
 COPY ${upstream_code}/lib  ${HOME}/lib
 COPY ${upstream_code}/Gemfile* ${HOME}/
 WORKDIR ${HOME}
 
-RUN for d in $(ls lib); do pushd lib/$d; rm *.gem; gem build *.gemspec; gem install -N --install-dir /usr/share/gems --bindir /usr/bin *.gem; popd; done && \
- CONFIGURE_ARGS="--with-cflags='$( rpm --eval %optflags )'" bundle install
+RUN CONFIGURE_ARGS="--with-cflags='$( rpm --eval %optflags )'" bundle install && \
+    for d in $(ls lib); do pushd lib/$d; gem build --force -V *.gemspec; \ 
+    gem install -N -minimal-deps --local --force --install-dir /usr/share/gems --bindir /usr/bin *.gem; popd; done
 
 #@follow_tag(registry.redhat.io/ubi8/ruby-27:latest)
 FROM registry.redhat.io/ubi8/ruby-27:1-73 AS runtime
@@ -63,7 +55,7 @@ ENV DATA_VERSION=$DATA_VERSION_VALUE \
     container=$CONTAINER_VALUE
 
 USER 0
-RUN RUNTIME_PKGS="hostname bc iproute" \
+RUN RUNTIME_PKGS="hostname bc iproute libxml2" \
  &&   yum install -y --setopt=tsflags=nodocs $RUNTIME_PKGS \
  &&   rpm -V $RUNTIME_PKGS \
  &&   yum clean all
@@ -72,10 +64,6 @@ RUN mkdir -p /etc/fluent/plugin
 
 COPY --from=builder /usr/bin/fluentd /usr/local/bin
 COPY --from=builder /usr/bin/fluent-cat /usr/local/bin
-COPY --from=builder /usr/local/lib/libjemalloc* /usr/local/lib
-COPY --from=builder /usr/local/bin/jemalloc-config /usr/local/bin
-COPY --from=builder /usr/local/bin/jemalloc.sh /usr/local/bin
-COPY --from=builder /usr/local/bin/jeprof /usr/local/bin
 
 COPY --from=builder /usr/share/gems /usr/share/gems
 COPY --from=builder /usr/lib64/gems/ruby /usr/lib64/gems/ruby

--- a/fluentd/Gemfile
+++ b/fluentd/Gemfile
@@ -16,12 +16,12 @@ gem 'fluent-plugin-prometheus'
 gem 'fluent-plugin-splunk-hec'
 gem 'fluent-plugin-label-router'
 gem 'kubeclient'
+gem 'libxml-ruby' #aws-sdk-core
 gem 'typhoeus'
 gem 'oj'
 gem 'bigdecimal'
 
 #Below gem(and two of its dependencies) are moved to O_A_L/fluentd/lib, but its dependencies still exist in O_A_L/fluentd/vendored_gem_src/
-#gem 'fluent-plugin-remote_syslog', '1.0.0'
 gem 'ffi'
 gem 'uuidtools'
 gem 'rake'

--- a/fluentd/Gemfile.lock
+++ b/fluentd/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       prometheus-client (>= 2.1.0)
     fluent-plugin-remote-syslog (1.2)
       fluent-mixin-config-placeholders
-      fluentd
+      fluentd (= 1.14.6)
       syslog_protocol
     fluent-plugin-remote_syslog (1.0.0)
       fluentd (= 1.14.6)
@@ -205,6 +205,7 @@ GEM
       jsonpath (~> 1.0)
       recursive-open-struct (~> 1.1, >= 1.1.1)
       rest-client (~> 2.0)
+    libxml-ruby (4.0.0)
     lru_redux (1.1.0)
     ltsv (0.1.2)
     mail (2.7.1)
@@ -325,6 +326,7 @@ DEPENDENCIES
   fluentd!
   formatter-single-json-value!
   kubeclient
+  libxml-ruby
   oj
   parser_viaq_host_audit!
   rake

--- a/fluentd/lib/fluent-plugin-remote-syslog/fluent-plugin-remote-syslog.gemspec
+++ b/fluentd/lib/fluent-plugin-remote-syslog/fluent-plugin-remote-syslog.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", "=1.14.6"
+  gem.add_runtime_dependency "fluentd", "=1.14.6"
   gem.add_dependency "fluent-mixin-config-placeholders"
   gem.add_dependency "syslog_protocol"
   gem.add_development_dependency "rake", ">= 0.9.2"

--- a/fluentd/lib/fluent-plugin-remote_syslog/fluent-plugin-remote_syslog.gemspec
+++ b/fluentd/lib/fluent-plugin-remote_syslog/fluent-plugin-remote_syslog.gemspec
@@ -17,5 +17,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit-rr"
 
   spec.add_runtime_dependency "fluentd", "=1.14.6"
-  spec.add_runtime_dependency "remote_syslog_sender", "=1.2.1"
 end

--- a/fluentd/lib/fluent-plugin-remote_syslog/test/plugin/out_remote_syslog.rb
+++ b/fluentd/lib/fluent-plugin-remote_syslog/test/plugin/out_remote_syslog.rb
@@ -46,7 +46,13 @@ class RemoteSyslogOutputTest < Test::Unit::TestCase
     ]
 
     mock.proxy(RemoteSyslogSender::UdpSender).new("example.com", 5566, whinyerrors: true, program: "minitest") do |sender|
-      mock.proxy(sender).transmit("foo",  facility: "user", severity: "debug", program: "minitest", hostname: "foo.com", rfc: :rfc3164)
+      packet_option = {}.tap do |po|
+        {facility: "user", severity: "debug", program: "minitest", hostname: "foo.com", rfc: :rfc3164}.each do|k,v|
+          po[k.to_sym] = v
+        end
+        po
+      end
+      mock.proxy(sender).transmit("foo",  packet_option)
     end
 
     d.run do
@@ -77,8 +83,16 @@ class RemoteSyslogOutputTest < Test::Unit::TestCase
       mock(klass).connect
     end
 
-    mock.proxy(RemoteSyslogSender::TcpSender).new("example.com", 5566, whinyerrors: true, program: "minitest", tls: false, packet_size: 1024, timeout: nil, timeout_exception: false, keep_alive: false, keep_alive_cnt: nil, keep_alive_idle: nil, keep_alive_intvl: nil) do |sender|
-      mock(sender).transmit("foo",  facility: "user", severity: "debug", program: "minitest", hostname: "foo.com", rfc: :rfc3164)
+    factory_args = {}
+    {whinyerrors: true, program: "minitest", tls: false, packet_size: 1024, timeout: nil, timeout_exception: false, keep_alive: false, keep_alive_cnt: nil, keep_alive_idle: nil, keep_alive_intvl: nil}.each do |k,v|
+      factory_args[k.to_sym] = v
+    end
+    mock.proxy(RemoteSyslogSender::TcpSender).new("example.com", 5566, factory_args) do |sender|
+      packet_options = {}
+      {facility: "user", severity: "debug", program: "minitest", hostname: "foo.com", rfc: :rfc3164}.each do |k,v|
+          packet_options[k.to_sym] = v
+      end
+      mock(sender).transmit("foo",  packet_options)
     end
 
     d.run do
@@ -111,8 +125,16 @@ class RemoteSyslogOutputTest < Test::Unit::TestCase
       mock(klass).connect
     end
 
-    mock.proxy(RemoteSyslogSender::TcpSender).new("example.com", 5566, whinyerrors: true, program: "fluentd", tls: false, packet_size: 1024, timeout: nil, timeout_exception: false, keep_alive: false, keep_alive_cnt: nil, keep_alive_idle: nil, keep_alive_intvl: nil) do |sender|
-      mock(sender).transmit("foo",  facility: "user", severity: "debug", appname: "minitest", procid: "miniproc", msgid: "minimsg", program: "fluentd", hostname: "foo.com", rfc: :rfc5424)
+    factory_args = {}
+    {whinyerrors: true, program: "fluentd", tls: false, packet_size: 1024, timeout: nil, timeout_exception: false, keep_alive: false, keep_alive_cnt: nil, keep_alive_idle: nil, keep_alive_intvl: nil}.each do |k,v|
+      factory_args[k.to_sym] = v
+    end
+    mock.proxy(RemoteSyslogSender::TcpSender).new("example.com", 5566, factory_args) do |sender|
+      packet_options = {}
+      {facility: "user", severity: "debug", appname: "minitest", procid: "miniproc", msgid: "minimsg", program: "fluentd", hostname: "foo.com", rfc: :rfc5424}.each do |k,v|
+          packet_options[k.to_sym] = v
+      end
+      mock(sender).transmit("foo",  packet_options)
     end
 
     d.run do

--- a/fluentd/lib/syslog_protocol/test/test_packet.rb
+++ b/fluentd/lib/syslog_protocol/test/test_packet.rb
@@ -76,7 +76,7 @@ describe "a syslog packet" do
   end
 
   it "timestamp must conform to the retarded format" do
-    @p.generate_timestamp_rfc3164.should.match /(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\s|[1-9])\d\s\d\d:\d\d:\d\d/
+    @p.generate_timestamp_rfc3164.should.match(/(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\s|[1-9])\d\s\d\d:\d\d:\d\d/)
   end
 
   it "use the current time and assemble the packet" do

--- a/fluentd/origin-meta.yaml
+++ b/fluentd/origin-meta.yaml
@@ -1,3 +1,3 @@
 from:
 - source: registry.redhat.io/ubi8/ruby-27:(\d)-(?:[\.0-9\-]*)
-  target: registry.access.redhat.com/ubi8/ruby-27
+  target: registry.access.redhat.com/ubi9/ruby-31


### PR DESCRIPTION
### Description
This PR:
* Updates fluent image to use ruby 3.1 availble on ubi9.1

Note: journal log collection against rhel8 based nodes is broken in the upstream until the 9.2 image can be released

### Links
* https://issues.redhat.com/browse/LOG-3471
* https://issues.redhat.com/browse/LOG-3832

replaces https://github.com/ViaQ/logging-fluentd/pull/56
