### PR TITLE
LOG-3832: update fluent 1.14.6 to use ruby-3.1 and ubi9

### DIFF
--- a/Dockerfile.unit
+++ b/Dockerfile.unit
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ruby-27
+FROM registry.access.redhat.com/ubi9/ruby-31
 
 ENV FLUENTD_VERSION=1.14.6 \
     WORKDIR=/tmp/fluentd/lib

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,31 +1,18 @@
 ### This is a generated file from Dockerfile.in ###
 #@follow_tag(registry.redhat.io/ubi8/ruby-27:latest)
-FROM registry.access.redhat.com/ubi8/ruby-27 AS builder
+FROM registry.access.redhat.com/ubi9/ruby-31 AS builder
 
 ENV REMOTE_SOURCES=${REMOTE_SOURCES:-"."}
 ENV REMOTE_SOURCES_DIR=${REMOTE_SOURCES_DIR:-"."}
 
 USER 0
-RUN : 'removed yum-config-manager' \
- &&   BUILD_PKGS="make gcc-c++ libffi-devel autoconf automake libtool m4 redhat-rpm-config" \
+RUN   BUILD_PKGS="make gcc-c++ libffi-devel autoconf automake libtool m4 redhat-rpm-config libxml2-devel" \
  &&   RUNTIME_PKGS="hostname bc iproute" \
  &&   yum install -y --setopt=tsflags=nodocs $BUILD_PKGS $RUNTIME_PKGS \
  &&   rpm -V $BUILD_PKGS \
  &&   rpm -V $RUNTIME_PKGS \
  &&   yum clean all
 
-
-ENV upstream_code=${upstream_code:-"."} \
-    HOME=/opt/app-root/src 
-COPY ${upstream_code}/jemalloc/ /tmp/jemalloc/
-RUN pushd /tmp/jemalloc && \
-        EXTRA_CFLAGS="$( rpm --eval '%{optflags}' )" ./autogen.sh && \
-        make install_lib_shared install_bin && \
-        cp COPYING /tmp/COPYING.jemalloc && \
-    popd
-
-COPY ${upstream_code}/source.jemalloc /source.jemalloc
-RUN bash -c '. /source.jemalloc; echo jemalloc $JEMALLOC_VER >> /contents'
 
 COPY ${upstream_code}/vendored_gem_src/ ${HOME}/vendored_gem_src/
 COPY ${upstream_code}/lib ${HOME}/vendored_gem_src
@@ -36,7 +23,7 @@ COPY ${upstream_code}/*.patch ${HOME}/vendored_gem_src/
 RUN cd ${HOME}/vendored_gem_src/ && ./install-gems.sh
 
 #@follow_tag(registry.redhat.io/ubi8/ruby-27:latest)
-FROM registry.access.redhat.com/ubi8/ruby-27 AS runtime
+FROM registry.access.redhat.com/ubi9/ruby-31 AS runtime
 
 ENV REMOTE_SOURCES=${REMOTE_SOURCES:-"."}
 ENV upstream_code=${upstream_code:-"."}
@@ -66,12 +53,8 @@ RUN RUNTIME_PKGS="hostname bc iproute" \
 
 RUN mkdir -p /etc/fluent/plugin
 
-COPY --from=builder /usr/local/lib/libjemalloc* /usr/local/lib
 COPY --from=builder /usr/local/bin/fluentd /usr/local/bin
 COPY --from=builder /usr/local/bin/fluent-cat /usr/local/bin
-COPY --from=builder /usr/local/bin/jemalloc-config /usr/local/bin
-COPY --from=builder /usr/local/bin/jemalloc.sh /usr/local/bin
-COPY --from=builder /usr/local/bin/jeprof /usr/local/bin
 
 COPY --from=builder /usr/local/share/gems /usr/local/share/gems
 COPY --from=builder /usr/local/lib64/gems/ruby /usr/local/lib64/gems/ruby

--- a/fluentd/Dockerfile.in
+++ b/fluentd/Dockerfile.in
@@ -5,8 +5,7 @@ ENV REMOTE_SOURCES=${REMOTE_SOURCES:-"."}
 ENV REMOTE_SOURCES_DIR=${REMOTE_SOURCES_DIR:-"."}
 
 USER 0
-RUN : 'removed yum-config-manager' \
- &&   BUILD_PKGS="make gcc-c++ libffi-devel autoconf automake libtool m4 redhat-rpm-config" \
+RUN   BUILD_PKGS="make gcc-c++ libffi-devel autoconf automake libtool m4 redhat-rpm-config libxml2-devel" \
  &&   RUNTIME_PKGS="hostname bc iproute" \
  &&   yum install -y --setopt=tsflags=nodocs $BUILD_PKGS $RUNTIME_PKGS \
  &&   rpm -V $BUILD_PKGS \
@@ -16,18 +15,6 @@ RUN : 'removed yum-config-manager' \
 ## EXCLUDE BEGIN ##
 ENV upstream_code=$REMOTE_SOURCES/fluentd/app/fluentd
 ## EXCLUDE END ##
-
-ENV upstream_code=${upstream_code:-"."} \
-    HOME=/opt/app-root/src 
-COPY ${upstream_code}/jemalloc/ /tmp/jemalloc/
-RUN pushd /tmp/jemalloc && \
-        EXTRA_CFLAGS="$( rpm --eval '%{optflags}' )" ./autogen.sh && \
-        make install_lib_shared install_bin && \
-        cp COPYING /tmp/COPYING.jemalloc && \
-    popd
-
-COPY ${upstream_code}/source.jemalloc /source.jemalloc
-RUN bash -c '. /source.jemalloc; echo jemalloc $JEMALLOC_VER >> /contents'
 
 COPY ${upstream_code}/vendored_gem_src/ ${HOME}/vendored_gem_src/
 COPY ${upstream_code}/lib ${HOME}/vendored_gem_src
@@ -71,12 +58,8 @@ RUN RUNTIME_PKGS="hostname bc iproute" \
 
 RUN mkdir -p /etc/fluent/plugin
 
-COPY --from=builder /usr/local/lib/libjemalloc* /usr/local/lib
 COPY --from=builder /usr/local/bin/fluentd /usr/local/bin
 COPY --from=builder /usr/local/bin/fluent-cat /usr/local/bin
-COPY --from=builder /usr/local/bin/jemalloc-config /usr/local/bin
-COPY --from=builder /usr/local/bin/jemalloc.sh /usr/local/bin
-COPY --from=builder /usr/local/bin/jeprof /usr/local/bin
 
 COPY --from=builder /usr/local/share/gems /usr/local/share/gems
 COPY --from=builder /usr/local/lib64/gems/ruby /usr/local/lib64/gems/ruby

--- a/fluentd/install-gems.sh
+++ b/fluentd/install-gems.sh
@@ -52,8 +52,6 @@ for dir in * ; do
         gem build -V $gem_name.gemspec
         exit 1
     }
-    gem_ver=$( gem spec --ruby *.gem | ruby -e 'gemspec=eval($stdin.read); puts gemspec.version.version' )
-    echo $gem_name $gem_ver >> $contents
     mv *.gem ..
     popd > /dev/null
 done

--- a/fluentd/origin-meta.yaml
+++ b/fluentd/origin-meta.yaml
@@ -1,3 +1,3 @@
 from:
 - source: registry.redhat.io/ubi8/ruby-27:(\d)-(?:[\.0-9\-]*)
-  target: registry.access.redhat.com/ubi8/ruby-27
+  target: registry.access.redhat.com/ubi9/ruby-31


### PR DESCRIPTION
### Description
This PR:
* updates to ruby v3.1
* updates base to ubi9
* removes use of jemalloc because of seg fault on ubi9

### Links
* https://issues.redhat.com/browse/LOG-3832