### PR TITLE
LOG-3761: Fix pattern of regex for JS client side multiline exception

### DIFF
--- a/fluentd/fluent-plugin-detect-exceptions.source0001.patch
+++ b/fluentd/fluent-plugin-detect-exceptions.source0001.patch
@@ -7,9 +7,9 @@ index d7c78b4..3eb52b3 100644
      JAVA_RULES = [
        rule([:start_state, :java_start_exception],
 -           /(?:Exception|Error|Throwable|V8 errors stack trace)[:\r\n]/,
-+           /(?:(Exception|Error|Throwable|V8 errors stack trace)[:\z\r\n]|java[x]?\..*(Exception|Error))/,
++           /(?:(Exception|Error|Throwable|V8 errors stack trace)[:\r\n]|java[x]?\..*(Exception|Error))/,
             :java_after_exception),
-+      rule([:start_state, :java_start_exception], /Error\s*$/, :java_after_exception),
++      rule([:start_state, :java_start_exception], /(Error\s*$|V8 errors stack trace\s*$)/, :java_after_exception),
        rule(:java_after_exception, /^[\t ]*nested exception is:[\t ]*/,
             :java_start_exception),
        rule(:java_after_exception, /^[\r\n]*$/, :java_after_exception),


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>

### Description
This PR adds regex to matching some V8 JavaScript exception, where `V8 errors stack trace` not ending with colon (`:`). 
For example: 
```
V8 errors stack trace
  eval at Foo.a (eval at Bar.z (myscript.js:10:3))
  at new Contructor.Name (native)
  at new FunctionName (unknown location)
  at Type.functionName [as methodName] (file(copy).js?query='yes':12:9)
  at functionName [as methodName] (native)
  at Type.main(sample(copy).js:6:4)
```

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com//browse/LOG-3761
- Enhancement proposal:
