### PR TITLE
[release-5.7]LOG-3815: Update rack to address fix CVE-2023-27539

### DIFF
--- a/fluentd/Gemfile.lock
+++ b/fluentd/Gemfile.lock
@@ -241,7 +241,7 @@ GEM
       protocol-hpack (~> 1.4)
       protocol-http (~> 0.18)
     public_suffix (4.0.7)
-    rack (3.0.4.2)
+    rack (3.0.6.1)
     rack-oauth2 (1.19.0)
       activesupport
       attr_required

--- a/fluentd/rh-manifest.txt
+++ b/fluentd/rh-manifest.txt
@@ -93,7 +93,7 @@ rubygem-nio4r 2.5.8 https://github.com/socketry/nio4r
 rubygem-oj 3.13.11 http://www.ohler.com/oj
 rubygem-prometheus-client 4.0.0 https://github.com/prometheus/client_ruby
 rubygem-public_suffix 4.0.7 https://simonecarletti.com/code/publicsuffix-ruby
-rubygem-rack 3.0.4.2 https://github.com/rack/rack
+rubygem-rack 3.0.6.1 https://github.com/rack/rack
 rubygem-rake 13.0.6 https://github.com/ruby/rake
 rubygem-recursive-open-struct 1.1.3 https://github.com/aetherknight/recursive-open-struct
 rubygem-rest-client 2.1.0 https://github.com/rest-client/rest-client

--- a/fluentd/vendored_gem_src/rack/CHANGELOG.md
+++ b/fluentd/vendored_gem_src/rack/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. For info on how to format all future additions to this file please reference [Keep A Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.0.6.1] - 2023-03-13
+
+- [CVE-2023-27539] Avoid ReDoS in header parsing
+
 ## [3.0.4.1] - 2023-03-02
 
 - [CVE-2023-27530] Introduce multipart_total_part_limit to limit total parts
@@ -12,7 +16,7 @@ All notable changes to this project will be documented in this file. For info on
 - [CVE-2022-44570] Fix ReDoS in Rack::Utils.get_byte_ranges
 - [CVE-2022-44572] Forbid control characters in attributes (also ReDoS)
 
-## [3.0.4] - 2022-01-17
+## [3.0.4] - 2023-01-17
 
 - `Rack::Request#POST` should consistently raise errors. Cache errors that occur when invoking `Rack::Request#POST` so they can be raised again later. ([#2010](https://github.com/rack/rack/pull/2010), [@ioquatix])
 - Fix `Rack::Lint` error message for `HTTP_CONTENT_TYPE` and `HTTP_CONTENT_LENGTH`. ([#2007](https://github.com/rack/rack/pull/2007), [@byroot](https://github.com/byroot))

--- a/fluentd/vendored_gem_src/rack/lib/rack.rb
+++ b/fluentd/vendored_gem_src/rack/lib/rack.rb
@@ -41,6 +41,7 @@ module Rack
   autoload :MethodOverride, "rack/method_override"
   autoload :Mime, "rack/mime"
   autoload :NullLogger, "rack/null_logger"
+  autoload :QueryParser, "rack/query_parser"
   autoload :Recursive, "rack/recursive"
   autoload :Reloader, "rack/reloader"
   autoload :RewindableInput, "rack/rewindable_input"

--- a/fluentd/vendored_gem_src/rack/lib/rack/constants.rb
+++ b/fluentd/vendored_gem_src/rack/lib/rack/constants.rb
@@ -54,11 +54,13 @@ module Rack
   RACK_RESPONSE_FINISHED              = 'rack.response_finished'
   RACK_REQUEST_FORM_INPUT             = 'rack.request.form_input'
   RACK_REQUEST_FORM_HASH              = 'rack.request.form_hash'
+  RACK_REQUEST_FORM_PAIRS             = 'rack.request.form_pairs'
   RACK_REQUEST_FORM_VARS              = 'rack.request.form_vars'
   RACK_REQUEST_FORM_ERROR             = 'rack.request.form_error'
   RACK_REQUEST_COOKIE_HASH            = 'rack.request.cookie_hash'
   RACK_REQUEST_COOKIE_STRING          = 'rack.request.cookie_string'
   RACK_REQUEST_QUERY_HASH             = 'rack.request.query_hash'
+  RACK_REQUEST_QUERY_PAIRS            = 'rack.request.query_pairs'
   RACK_REQUEST_QUERY_STRING           = 'rack.request.query_string'
   RACK_METHODOVERRIDE_ORIGINAL_METHOD = 'rack.methodoverride.original_method'
 end

--- a/fluentd/vendored_gem_src/rack/lib/rack/multipart.rb
+++ b/fluentd/vendored_gem_src/rack/lib/rack/multipart.rb
@@ -13,6 +13,31 @@ module Rack
   module Multipart
     MULTIPART_BOUNDARY = "AaB03x"
 
+    # Accumulator for multipart form data, conforming to the QueryParser API.
+    # In future, the Parser could return the pair list directly, but that would
+    # change its API.
+    class ParamList # :nodoc:
+      def self.make_params
+        new
+      end
+
+      def self.normalize_params(params, key, value)
+        params << [key, value]
+      end
+
+      def initialize
+        @pairs = []
+      end
+
+      def <<(pair)
+        @pairs << pair
+      end
+
+      def to_params_hash
+        @pairs
+      end
+    end
+
     class << self
       def parse_multipart(env, params = Rack::Utils.default_query_parser)
         io = env[RACK_INPUT]

--- a/fluentd/vendored_gem_src/rack/lib/rack/query_parser.rb
+++ b/fluentd/vendored_gem_src/rack/lib/rack/query_parser.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'uri'
+
 module Rack
   class QueryParser
     DEFAULT_SEP = /[&] */n
@@ -37,19 +39,42 @@ module Rack
       @param_depth_limit = param_depth_limit
     end
 
-    # Stolen from Mongrel, with some small modifications:
+    # Originally stolen from Mongrel, now with some modifications:
     # Parses a query string by breaking it up at the '&'.  You can also use this
     # to parse cookies by changing the characters used in the second parameter
     # (which defaults to '&').
-    def parse_query(qs, separator = nil, &unescaper)
-      unescaper ||= method(:unescape)
+    #
+    # Returns an array of 2-element arrays, where the first element is the
+    # key and the second element is the value.
+    def split_query(qs, separator = nil, &unescaper)
+      pairs = []
 
+      if qs && !qs.empty?
+        unescaper ||= method(:unescape)
+
+        qs.split(separator ? (COMMON_SEP[separator] || /[#{separator}] */n) : DEFAULT_SEP).each do |p|
+          next if p.empty?
+          pair = p.split('=', 2).map!(&unescaper)
+          pair << nil if pair.length == 1
+          pairs << pair
+        end
+      end
+
+      pairs
+    rescue ArgumentError => e
+      raise InvalidParameterError, e.message, e.backtrace
+    end
+
+    # Parses a query string by breaking it up at the '&'.  You can also use this
+    # to parse cookies by changing the characters used in the second parameter
+    # (which defaults to '&').
+    #
+    # Returns a hash where each value is a string (when a key only appears once)
+    # or an array of strings (when a key appears more than once).
+    def parse_query(qs, separator = nil, &unescaper)
       params = make_params
 
-      (qs || '').split(separator ? (COMMON_SEP[separator] || /[#{separator}] */n) : DEFAULT_SEP).each do |p|
-        next if p.empty?
-        k, v = p.split('=', 2).map!(&unescaper)
-
+      split_query(qs, separator, &unescaper).each do |k, v|
         if cur = params[k]
           if cur.class == Array
             params[k] << v
@@ -61,7 +86,7 @@ module Rack
         end
       end
 
-      return params.to_h
+      params.to_h
     end
 
     # parse_nested_query expands a query string into structural types. Supported
@@ -72,17 +97,11 @@ module Rack
     def parse_nested_query(qs, separator = nil)
       params = make_params
 
-      unless qs.nil? || qs.empty?
-        (qs || '').split(separator ? (COMMON_SEP[separator] || /[#{separator}] */n) : DEFAULT_SEP).each do |p|
-          k, v = p.split('=', 2).map! { |s| unescape(s) }
-
-          _normalize_params(params, k, v, 0)
-        end
+      split_query(qs, separator).each do |k, v|
+        _normalize_params(params, k, v, 0)
       end
 
-      return params.to_h
-    rescue ArgumentError => e
-      raise InvalidParameterError, e.message, e.backtrace
+      params.to_h
     end
 
     # normalize_params recursively expands parameters into structural types. If
@@ -92,6 +111,14 @@ module Rack
     # earlier versions of rack.
     def normalize_params(params, name, v, _depth=nil)
       _normalize_params(params, name, v, 0)
+    end
+
+    # This value is used by default when a parameter is missing (nil). This
+    # usually happens when a parameter is specified without an `=value` part.
+    # The default value is an empty string, but this can be overridden by
+    # subclasses.
+    def missing_value
+      String.new
     end
 
     private def _normalize_params(params, name, v, depth)
@@ -128,7 +155,7 @@ module Rack
 
       return if k.empty?
 
-      v ||= String.new
+      v ||= missing_value
 
       if after == ''
         if k == '[]' && depth != 0
@@ -190,8 +217,8 @@ module Rack
       true
     end
 
-    def unescape(s)
-      Utils.unescape(s)
+    def unescape(string, encoding = Encoding::UTF_8)
+      URI.decode_www_form_component(string, encoding)
     end
 
     class Params

--- a/fluentd/vendored_gem_src/rack/lib/rack/request.rb
+++ b/fluentd/vendored_gem_src/rack/lib/rack/request.rb
@@ -483,11 +483,22 @@ module Rack
       # Returns the data received in the query string.
       def GET
         if get_header(RACK_REQUEST_QUERY_STRING) == query_string
-          get_header(RACK_REQUEST_QUERY_HASH)
+          if query_hash = get_header(RACK_REQUEST_QUERY_HASH)
+            return query_hash
+          end
+        end
+
+        set_header(RACK_REQUEST_QUERY_HASH, expand_params(query_param_list))
+      end
+
+      def query_param_list
+        if get_header(RACK_REQUEST_QUERY_STRING) == query_string
+          get_header(RACK_REQUEST_QUERY_PAIRS)
         else
-          query_hash = parse_query(query_string, '&')
-          set_header(RACK_REQUEST_QUERY_STRING, query_string)
-          set_header(RACK_REQUEST_QUERY_HASH, query_hash)
+          query_pairs = split_query(query_string, '&')
+          set_header RACK_REQUEST_QUERY_STRING, query_string
+          set_header RACK_REQUEST_QUERY_HASH, nil
+          set_header(RACK_REQUEST_QUERY_PAIRS, query_pairs)
         end
       end
 
@@ -496,32 +507,53 @@ module Rack
       # This method support both application/x-www-form-urlencoded and
       # multipart/form-data.
       def POST
+        if get_header(RACK_REQUEST_FORM_INPUT).equal?(get_header(RACK_INPUT))
+          if form_hash = get_header(RACK_REQUEST_FORM_HASH)
+            return form_hash
+          end
+        end
+
+        set_header(RACK_REQUEST_FORM_HASH, expand_params(body_param_list))
+      end
+
+      def body_param_list
         if error = get_header(RACK_REQUEST_FORM_ERROR)
           raise error.class, error.message, cause: error.cause
         end
 
         begin
-          if get_header(RACK_INPUT).nil?
-            raise "Missing rack.input"
-          elsif get_header(RACK_REQUEST_FORM_INPUT) == get_header(RACK_INPUT)
-            get_header(RACK_REQUEST_FORM_HASH)
+          rack_input = get_header(RACK_INPUT)
+
+          form_pairs = nil
+
+          # If the form data has already been memoized from the same
+          # input:
+          if get_header(RACK_REQUEST_FORM_INPUT).equal?(rack_input)
+            if form_pairs = get_header(RACK_REQUEST_FORM_PAIRS)
+              return form_pairs
+            end
+          end
+
+          if rack_input.nil?
+            form_pairs = []
           elsif form_data? || parseable_data?
-            unless set_header(RACK_REQUEST_FORM_HASH, parse_multipart)
-              form_vars = get_header(RACK_INPUT).read
+            unless form_pairs = Rack::Multipart.extract_multipart(self, Rack::Multipart::ParamList)
+              form_vars = rack_input.read
 
               # Fix for Safari Ajax postings that always append \0
               # form_vars.sub!(/\0\z/, '') # performance replacement:
               form_vars.slice!(-1) if form_vars.end_with?("\0")
 
               set_header RACK_REQUEST_FORM_VARS, form_vars
-              set_header RACK_REQUEST_FORM_HASH, parse_query(form_vars, '&')
+              form_pairs = split_query(form_vars, '&')
             end
-            set_header RACK_REQUEST_FORM_INPUT, get_header(RACK_INPUT)
-            get_header RACK_REQUEST_FORM_HASH
           else
-            set_header RACK_REQUEST_FORM_INPUT, get_header(RACK_INPUT)
-            set_header(RACK_REQUEST_FORM_HASH, {})
+            form_pairs = []
           end
+
+          set_header RACK_REQUEST_FORM_INPUT, rack_input
+          set_header RACK_REQUEST_FORM_HASH, nil
+          set_header(RACK_REQUEST_FORM_PAIRS, form_pairs)
         rescue => error
           set_header(RACK_REQUEST_FORM_ERROR, error)
           raise
@@ -634,8 +666,8 @@ module Rack
       end
 
       def parse_http_accept_header(header)
-        header.to_s.split(/\s*,\s*/).map do |part|
-          attribute, parameters = part.split(/\s*;\s*/, 2)
+        header.to_s.split(",").each(&:strip!).map do |part|
+          attribute, parameters = part.split(";", 2).each(&:strip!)
           quality = 1.0
           if parameters and /\Aq=([\d.]+)/ =~ parameters
             quality = $1.to_f
@@ -659,6 +691,28 @@ module Rack
 
       def parse_multipart
         Rack::Multipart.extract_multipart(self, query_parser)
+      end
+
+      def split_query(query, d = '&')
+        query_parser = query_parser()
+        unless query_parser.respond_to?(:split_query)
+          query_parser = Utils.default_query_parser
+          unless query_parser.respond_to?(:split_query)
+            query_parser = QueryParser.make_default(0)
+          end
+        end
+
+        query_parser.split_query(query, d)
+      end
+
+      def expand_params(pairs, query_parser = query_parser())
+        params = query_parser.make_params
+
+        pairs.each do |key, value|
+          query_parser.normalize_params(params, key, value)
+        end
+
+        params.to_params_hash
       end
 
       def split_header(value)

--- a/fluentd/vendored_gem_src/rack/lib/rack/version.rb
+++ b/fluentd/vendored_gem_src/rack/lib/rack/version.rb
@@ -25,7 +25,7 @@ module Rack
     VERSION
   end
 
-  RELEASE = "3.0.4.2"
+  RELEASE = "3.0.6.1"
 
   # Return the Rack release as a dotted string.
   def self.release

--- a/fluentd/vendored_gem_src/rack/rack.gemspec
+++ b/fluentd/vendored_gem_src/rack/rack.gemspec
@@ -1,15 +1,15 @@
 # -*- encoding: utf-8 -*-
-# stub: rack 3.0.4.2 ruby lib
+# stub: rack 3.0.6.1 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "rack".freeze
-  s.version = "3.0.4.2"
+  s.version = "3.0.6.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "bug_tracker_uri" => "https://github.com/rack/rack/issues", "changelog_uri" => "https://github.com/rack/rack/blob/main/CHANGELOG.md", "documentation_uri" => "https://rubydoc.info/github/rack/rack", "source_code_uri" => "https://github.com/rack/rack" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Leah Neukirchen".freeze]
-  s.date = "2023-03-02"
+  s.date = "2023-03-13"
   s.description = "Rack provides a minimal, modular and adaptable interface for developing\nweb applications in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible, it unifies and distills the API for web\nservers, web frameworks, and software in between (the so-called\nmiddleware) into a single method call.\n".freeze
   s.email = "leah@vuxu.org".freeze
   s.extra_rdoc_files = ["README.md".freeze, "CHANGELOG.md".freeze, "CONTRIBUTING.md".freeze]


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>

### Description
This PR update rack version to the `3.0.6.1` to address fix `CVE 2023-27539` ([ruby-advisory-db/CVE-2023-27539](https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rack/CVE-2023-27539.yml))

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:[issues.redhat.com/browse/LOG-3815](https://issues.redhat.com/browse/LOG-3815)
- Enhancement proposal:
