### PR TITLE
LOG-4012: patch loki plugin to support ciphers, min_version

### DIFF
--- a/fluentd/fluent-plugin-grafana-loki.source0001.patch
+++ b/fluentd/fluent-plugin-grafana-loki.source0001.patch
@@ -1,0 +1,37 @@
+diff --git a/lib/fluent/plugin/out_loki.rb b/lib/fluent/plugin/out_loki.rb
+index c72aa2adc..f2bb30538 100644
+--- a/lib/fluent/plugin/out_loki.rb
++++ b/lib/fluent/plugin/out_loki.rb
+@@ -52,6 +52,12 @@ module Fluent
+       desc 'TLS: CA certificate file for server certificate verification'
+       config_param :ca_cert, :string, default: nil
+ 
++      desc 'TLS: the ciphers to use for the tls connection (e.g TLS1_0, TLS1_1, TLS1_2)'
++      config_param :ciphers, :string, default: nil
++
++      desc 'TLS: The minimum version for the tls connection'
++      config_param :min_version, :string, default: nil
++
+       desc 'TLS: disable server certificate verification'
+       config_param :insecure_tls, :bool, default: false
+ 
+@@ -198,6 +204,19 @@ module Fluent
+             ca_file: @ca_cert
+           )
+         end
++
++        if @ciphers
++          opts = opts.merge(
++            ciphers: @ciphers
++          )
++        end
++
++        if @min_version
++          opts = opts.merge(
++            min_version: @min_version.to_sym
++          )
++        end
++
+         opts
+       end
+ 


### PR DESCRIPTION
### Description
This PR:
* adds a patch to fluent loki plugin to honor ciphers and min_version

### Links
* https://issues.redhat.com/browse/LOG-4012
