### PR TITLE
LOG-4150: add patch for: Fluentd fix missing nil check for rotated_tw in update_watcher

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -66,7 +66,9 @@ RUN  mv /usr/share/gems/aws-sdk-core.source0001.patch /usr/share/gems/gems/aws-s
      cd /usr/share/gems/gems/aws-sdk-core-*/ && patch -p1 < aws-sdk-core.source0001.patch && \
      cd /usr/share/gems &&  \
      mv /usr/share/gems/fluent-plugin-detect-exceptions.source0001.patch /usr/share/gems/gems/fluent-plugin-detect-exceptions-*/ && \
-     cd /usr/share/gems/gems/fluent-plugin-detect-exceptions-*/ && patch -p1 < fluent-plugin-detect-exceptions.source0001.patch
+     cd /usr/share/gems/gems/fluent-plugin-detect-exceptions-*/ && patch -p1 < fluent-plugin-detect-exceptions.source0001.patch && \
+     mv /usr/share/gems/fluentd.source0001.patch /usr/share/gems/gems/fluentd-*/ && \
+     cd /usr/share/gems/gems/fluentd-*/ && patch -p1 < fluentd.source0001.patch
 
 RUN mkdir -p /etc/fluent/configs.d/user && \
     chmod 777 /etc/fluent/configs.d/user && \

--- a/fluentd/fluentd.source0001.patch
+++ b/fluentd/fluentd.source0001.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/fluent/plugin/in_tail.rb b/lib/fluent/plugin/in_tail.rb
+index 3ad5943f8..ac38f5eeb 100644
+--- a/lib/fluent/plugin/in_tail.rb
++++ b/lib/fluent/plugin/in_tail.rb
+@@ -509,7 +509,7 @@ module Fluent::Plugin
+         if new_position_entry.read_inode == 0
+           # When follow_inodes is true, it's not cleaned up by refresh_watcher.
+           # So it should be unwatched here explicitly.
+-          rotated_tw.unwatched = true
++          rotated_tw.unwatched = true if rotated_tw
+           # Make sure to delete old key, it has a different ino while the hash key is same.
+           @tails.delete(rotated_target_info)
+           @tails[new_target_info] = setup_watcher(new_target_info, new_position_entry)


### PR DESCRIPTION
### Description
This PR fix a possible crash on file rotation when `follow_inodes` is  `true` by adds patch file based on changes introduced in https://github.com/fluent/fluentd/pull/3754

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4150
- Enhancement proposal:
