### PR TITLE
LOG-4316: Update fluent-plugin-splunk-hec to v1.3.2

### DIFF
--- a/fluentd/Gemfile
+++ b/fluentd/Gemfile
@@ -13,7 +13,7 @@ gem 'fluent-plugin-record-modifier'
 gem 'fluent-plugin-rewrite-tag-filter'
 gem 'fluent-plugin-systemd'
 gem 'fluent-plugin-prometheus'
-gem 'fluent-plugin-splunk-hec'
+gem 'fluent-plugin-splunk-hec', '1.3.2'
 gem 'fluent-plugin-label-router'
 gem 'kubeclient'
 gem 'libxml-ruby' #aws-sdk-core

--- a/fluentd/Gemfile.lock
+++ b/fluentd/Gemfile.lock
@@ -27,14 +27,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.7.3)
-      activesupport (= 6.1.7.3)
-    activesupport (6.1.7.3)
+    activemodel (7.0.6)
+      activesupport (= 7.0.6)
+    activesupport (7.0.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
@@ -68,12 +67,13 @@ GEM
     aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
     bigdecimal (3.1.2)
-    bindata (2.4.10)
+    bindata (2.4.15)
     concurrent-ruby (1.1.10)
-    connection_pool (2.2.5)
+    connection_pool (2.4.1)
     console (1.15.0)
       fiber-local
     cool.io (1.7.1)
+    date (3.3.3)
     digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.5.20190701)
@@ -112,6 +112,8 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
+    faraday_middleware (1.2.0)
+      faraday (~> 1.0)
     ffi (1.15.5)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
@@ -156,12 +158,14 @@ GEM
     fluent-plugin-rewrite-tag-filter (2.4.0)
       fluent-config-regexp-type
       fluentd (>= 0.14.2, < 2)
-    fluent-plugin-splunk-hec (1.2.13)
-      fluentd (>= 1.4)
+    fluent-plugin-splunk-hec (1.3.2)
+      fluentd (>= 1.5)
+      json-jwt (~> 1.15.0)
       multi_json (~> 1.13)
       net-http-persistent (~> 4.0)
       openid_connect (~> 1.1.8)
       prometheus-client (>= 2.1.0)
+      rack-oauth2 (~> 1.19)
     fluent-plugin-systemd (1.0.5)
       fluentd (>= 0.14.11, < 2)
       systemd-journal (~> 1.4.2)
@@ -190,13 +194,14 @@ GEM
       ffi-compiler (>= 1.0, < 2.0)
     http_parser.rb (0.8.0)
     httpclient (2.8.3)
-    i18n (1.10.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.1)
-    json-jwt (1.13.0)
+    json-jwt (1.15.3)
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
+      httpclient
     jsonpath (1.1.2)
       multi_json
     kubeclient (4.9.3)
@@ -207,18 +212,30 @@ GEM
     libxml-ruby (4.0.0)
     lru_redux (1.1.0)
     ltsv (0.1.2)
-    mail (2.7.1)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
-    minitest (5.15.0)
+    minitest (5.18.1)
     msgpack (1.5.4)
     multi_json (1.15.0)
     multipart-post (2.1.1)
-    net-http-persistent (4.0.1)
+    net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
+    net-imap (0.3.6)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
     oj (3.13.11)
@@ -241,8 +258,8 @@ GEM
       protocol-hpack (~> 1.4)
       protocol-http (~> 0.18)
     public_suffix (4.0.7)
-    rack (3.0.6.1)
-    rack-oauth2 (1.19.0)
+    rack (3.0.8)
+    rack-oauth2 (1.21.3)
       activesupport
       attr_required
       httpclient
@@ -268,6 +285,7 @@ GEM
       httpclient (>= 2.4)
     systemd-journal (1.4.2)
       ffi (~> 1.9)
+    timeout (0.4.0)
     timers (4.3.3)
     traces (0.4.1)
     typhoeus (1.4.0)
@@ -283,15 +301,15 @@ GEM
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
-    validate_url (1.0.13)
+    validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
-    webfinger (1.2.0)
+    webfinger (2.0.0)
       activesupport
-      httpclient (>= 2.4)
+      faraday (~> 1.7)
+      faraday_middleware (~> 1.1)
     webrick (1.7.0)
     yajl-ruby (1.4.3)
-    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby
@@ -319,10 +337,10 @@ DEPENDENCIES
   fluent-plugin-remote-syslog!
   fluent-plugin-remote_syslog!
   fluent-plugin-rewrite-tag-filter
-  fluent-plugin-splunk-hec
+  fluent-plugin-splunk-hec (= 1.3.2)
   fluent-plugin-systemd
   fluent-plugin-viaq_data_model (= 0.0.23)!
-  fluentd!
+  fluentd (= 1.14.6)!
   formatter-single-json-value!
   kubeclient
   libxml-ruby


### PR DESCRIPTION
### Description
This PR:
* updates  fluent-plugin-splunk-hec to v1.3.2 to force the upgrade of activesupport gem to 7.0.6

### Links
* https://issues.redhat.com/browse/LOG-4316