### PR TITLE
LOG-4366: fix ruby net/http.rb to honor no_proxy in start method

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -32,7 +32,9 @@ RUN  mv /usr/share/gems/aws-sdk-core.source0001.patch /usr/share/gems/gems/aws-s
      mv /usr/share/gems/fluent-plugin-detect-exceptions.source0001.patch /usr/share/gems/gems/fluent-plugin-detect-exceptions-*/ && \
      cd /usr/share/gems/gems/fluent-plugin-detect-exceptions-*/ && patch -p1 < fluent-plugin-detect-exceptions.source0001.patch && \
      mv /usr/share/gems/fluent-plugin-elasticsearch.source0001.patch /usr/share/gems/gems/fluent-plugin-elasticsearch-*/ && \
-     cd /usr/share/gems/gems/fluent-plugin-elasticsearch-*/ && patch -p1 < fluent-plugin-elasticsearch.source0001.patch
+     cd /usr/share/gems/gems/fluent-plugin-elasticsearch-*/ && patch -p1 < fluent-plugin-elasticsearch.source0001.patch && \
+     mv /usr/share/gems/log4366_ruby_lib_net_http.patch /usr/share/ruby/ && \
+     cd /usr/share/ruby && patch -p1 < log4366_ruby_lib_net_http.patch
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal AS runtime
 
@@ -70,6 +72,7 @@ COPY --from=builder /usr/bin/fluent-cat /usr/local/bin
 
 COPY --from=builder /usr/share/gems /usr/share/gems
 COPY --from=builder /usr/lib64/gems/ruby /usr/lib64/gems/ruby
+COPY --from=builder /usr/share/ruby/net/http.rb /usr/share/ruby/net/
 COPY ${upstream_code}/run.sh ${HOME}/
 COPY ${upstream_code}/utils/ /usr/local/bin/
 

--- a/fluentd/log4366_ruby_lib_net_http.patch
+++ b/fluentd/log4366_ruby_lib_net_http.patch
@@ -1,0 +1,23 @@
+diff --git a/net/http.rb b/net/http.rb
+index 88a174a248..4da8dfa894 100644
+--- a/net/http.rb
++++ b/net/http.rb
+@@ -589,7 +589,7 @@ def HTTP.start(address, *arg, &block) # :yield: +http+
+       port, p_addr, p_port, p_user, p_pass = *arg
+       p_addr = :ENV if arg.size < 2
+       port = https_default_port if !port && opt && opt[:use_ssl]
+-      http = new(address, port, p_addr, p_port, p_user, p_pass)
++      http = new(address, port, p_addr, p_port, p_user, p_pass, (ENV['NO_PROXY']||ENV['no_proxy']))
+       http.ipaddr = opt[:ipaddr] if opt && opt[:ipaddr]
+ 
+       if opt
+@@ -642,7 +642,8 @@ def HTTP.new(address, port = nil, p_addr = :ENV, p_port = nil, p_user = nil, p_p
+       elsif p_addr == :ENV then
+         http.proxy_from_env = true
+       else
+-        if p_addr && p_no_proxy && !URI::Generic.use_proxy?(p_addr, p_addr, p_port, p_no_proxy)
++        # patched: https://github.com/ruby/net-http/pull/64
++        if p_addr && p_no_proxy && !URI::Generic.use_proxy?(address, address, p_port, p_no_proxy)
+           p_addr = nil
+           p_port = nil
+         end


### PR DESCRIPTION
### Description
This PR:
* modifies ruby net/http.rb HTTP#start to check the env no proxy vars
* prefers NO_PROXY over no_proxy

### Links
* https://issues.redhat.com/browse/LOG-4366
* https://issues.redhat.com/browse/LOG-4784
