### PR TITLE
LOG-4366: fix ruby net/http.rb to honor no_proxy in start method

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -32,6 +32,7 @@ COPY ${upstream_code}/lib ${HOME}/vendored_gem_src
 COPY ${upstream_code}/install-gems.sh ${HOME}/vendored_gem_src/
 COPY ${upstream_code}/*.patch.sh ${HOME}/vendored_gem_src/
 COPY ${upstream_code}/*.patch ${HOME}/vendored_gem_src/
+RUN rm ${HOME}/vendored_gem_src/log4366_ruby_lib_net_http.patch
 
 RUN cd ${HOME}/vendored_gem_src/ && ./install-gems.sh
 
@@ -83,6 +84,9 @@ COPY ${upstream_code}/generate_syslog_config.rb ${HOME}/
 COPY ${upstream_code}/wait_for_es_version.rb ${HOME}/
 COPY ${upstream_code}/wait_for_es_version.sh ${HOME}/
 COPY ${upstream_code}/utils/ /usr/local/bin/
+
+COPY ${upstream_code}/log4366_ruby_lib_net_http.patch /usr/share/ruby/
+RUN  cd /usr/share/ruby && patch -p1 < log4366_ruby_lib_net_http.patch
 
 RUN mkdir -p /etc/fluent/configs.d/user && \
     chmod 777 /etc/fluent/configs.d/user && \

--- a/fluentd/Dockerfile.in
+++ b/fluentd/Dockerfile.in
@@ -34,6 +34,7 @@ COPY ${upstream_code}/lib ${HOME}/vendored_gem_src
 COPY ${upstream_code}/install-gems.sh ${HOME}/vendored_gem_src/
 COPY ${upstream_code}/*.patch.sh ${HOME}/vendored_gem_src/
 COPY ${upstream_code}/*.patch ${HOME}/vendored_gem_src/
+RUN rm ${HOME}/vendored_gem_src/log4366_ruby_lib_net_http.patch
 
 RUN cd ${HOME}/vendored_gem_src/ && ./install-gems.sh
 
@@ -88,6 +89,9 @@ COPY ${upstream_code}/generate_syslog_config.rb ${HOME}/
 COPY ${upstream_code}/wait_for_es_version.rb ${HOME}/
 COPY ${upstream_code}/wait_for_es_version.sh ${HOME}/
 COPY ${upstream_code}/utils/ /usr/local/bin/
+
+COPY ${upstream_code}/log4366_ruby_lib_net_http.patch /usr/share/ruby/
+RUN  cd /usr/share/ruby && patch -p1 < log4366_ruby_lib_net_http.patch
 
 RUN mkdir -p /etc/fluent/configs.d/user && \
     chmod 777 /etc/fluent/configs.d/user && \

--- a/fluentd/log4366_ruby_lib_net_http.patch
+++ b/fluentd/log4366_ruby_lib_net_http.patch
@@ -1,0 +1,13 @@
+diff --git a/net/http.rb b/net/http.rb
+index 88a174a248..3e76c63503 100644
+--- a/net/http.rb
++++ b/net/http.rb
+@@ -589,7 +589,7 @@ def HTTP.start(address, *arg, &block) # :yield: +http+
+       port, p_addr, p_port, p_user, p_pass = *arg
+       p_addr = :ENV if arg.size < 2
+       port = https_default_port if !port && opt && opt[:use_ssl]
+-      http = new(address, port, p_addr, p_port, p_user, p_pass)
++      http = new(address, port, p_addr, p_port, p_user, p_pass, (ENV['NO_PROXY']||ENV['no_proxy']))
+       http.ipaddr = opt[:ipaddr] if opt && opt[:ipaddr]
+ 
+       if opt


### PR DESCRIPTION
### Description
This PR:
* modifies ruby net/http.rb HTTP#start to check the env no proxy vars
* prefers NO_PROXY over no_proxy

### Links
* https://issues.redhat.com/browse/LOG-4366
* related to #100 