### PR TITLE
LOG-4489: update ActiveSupport gem from 7.0.6 to 7.0.8 to fix vulnerability CVE-2023-38037 

### DIFF
--- a/fluentd/Gemfile.lock
+++ b/fluentd/Gemfile.lock
@@ -27,9 +27,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.6)
-      activesupport (= 7.0.6)
-    activesupport (7.0.6)
+    activemodel (7.0.8)
+      activesupport (= 7.0.8)
+    activesupport (7.0.8)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)


### PR DESCRIPTION
### Description
This PR update `ActiveSupport` gem from `7.0.6` to `7.0.8` to fix vulnerability `CVE-2023-38037: Possible File Disclosure of Locally Encrypted Files`
More info see here: https://github.com/rubysec/ruby-advisory-db/blob/master/gems/activesupport/CVE-2023-38037.yml

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4489
- Enhancement proposal:
