### PR TITLE
LOG-4811: Fluentd is unable to forward logs to external ipv6 elasticsearch instance

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -30,7 +30,9 @@ RUN  mv /usr/share/gems/aws-sdk-core.source0001.patch /usr/share/gems/gems/aws-s
      cd /usr/share/gems/gems/aws-sdk-core-*/ && patch -p1 < aws-sdk-core.source0001.patch && \
      cd /usr/share/gems &&  \
      mv /usr/share/gems/fluent-plugin-detect-exceptions.source0001.patch /usr/share/gems/gems/fluent-plugin-detect-exceptions-*/ && \
-     cd /usr/share/gems/gems/fluent-plugin-detect-exceptions-*/ && patch -p1 < fluent-plugin-detect-exceptions.source0001.patch
+     cd /usr/share/gems/gems/fluent-plugin-detect-exceptions-*/ && patch -p1 < fluent-plugin-detect-exceptions.source0001.patch && \
+     mv /usr/share/gems/fluent-plugin-elasticsearch.source0001.patch /usr/share/gems/gems/fluent-plugin-elasticsearch-*/ && \
+     cd /usr/share/gems/gems/fluent-plugin-elasticsearch-*/ && patch -p1 < fluent-plugin-elasticsearch.source0001.patch
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal AS runtime
 

--- a/fluentd/fluent-plugin-elasticsearch.source0001.patch
+++ b/fluentd/fluent-plugin-elasticsearch.source0001.patch
@@ -1,0 +1,41 @@
+diff --git a/lib/fluent/plugin/out_elasticsearch.rb b/lib/fluent/plugin/out_elasticsearch.rb
+index 8780f0aef..e881a3f03 100644
+--- a/lib/fluent/plugin/out_elasticsearch.rb
++++ b/lib/fluent/plugin/out_elasticsearch.rb
+@@ -651,6 +651,14 @@ EOC
+       end
+     end
+ 
++    def is_ipv6_host(host_str)
++      begin
++        IPAddr.new(host_str).ipv6?
++      rescue IPAddr::InvalidAddressError
++        return false
++      end
++    end
++
+     def get_connection_options(con_host=nil)
+ 
+       hosts = if con_host || @hosts
+@@ -662,6 +670,21 @@ EOC
+               port:   (host_str.split(':')[1] || @port).to_i,
+               scheme: @scheme.to_s
+             }
++          # Support ipv6 for host/host placeholders
++          elsif is_ipv6_host(host_str)
++            if Resolv::IPv6::Regex.match(host_str)
++              {
++                host: "[#{host_str}]",
++                port: @port.to_i,
++                scheme: @scheme.to_s 
++              }
++            else
++              {
++                host: host_str,
++                port: @port.to_i, 
++                scheme: @scheme.to_s
++              }
++            end
+           else
+             # New hosts format expects URLs such as http://logs.foo.com,https://john:pass@logs2.foo.com/elastic
+             uri = URI(get_escaped_userinfo(host_str))


### PR DESCRIPTION
### Description
This is a forward port of https://github.com/ViaQ/logging-fluentd/pull/105.

#### Summary:
This PR fixes support for host/hosts placeholders specifically for ipv6 addresses.
Before this fix, IPv6 addresses would not be parsed correctly after evaluating host/hosts for placeholders.

/cc @cahartma 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4811
