### PR TITLE
LOG-3933: Upgrade openssl gem to v3.2.0 to read private key in FIPS mode

### DIFF
--- a/fluentd/Gemfile
+++ b/fluentd/Gemfile
@@ -21,6 +21,7 @@ gem 'typhoeus' # gems that supports elasticsearch
 # gems that support fluentd
 gem 'oj'
 gem 'bigdecimal'
+gem 'openssl', '3.2.0' #LOG-3933
 
 gem 'rake'
 

--- a/fluentd/Gemfile.lock
+++ b/fluentd/Gemfile.lock
@@ -229,6 +229,7 @@ GEM
       validate_email
       validate_url
       webfinger (>= 1.0.1)
+    openssl (3.2.0)
     prometheus-client (4.0.0)
     public_suffix (4.0.7)
     rack (3.0.8)
@@ -312,6 +313,7 @@ DEPENDENCIES
   formatter-single-json-value!
   libxml-ruby
   oj
+  openssl (= 3.2.0)
   parser_viaq_host_audit!
   rake
   remote_syslog_sender!


### PR DESCRIPTION
### Description
This PR:
* Updates openssl to 3.2.0 as advised by RHEL team to support reading private key on FIPS enabled cluster

### Links
* https://issues.redhat.com/browse/LOG-3933
