### PR TITLE
LOG-6122: update webrick lib to 1.8.2 to fix CVE-2024-47220

### DIFF
--- a/fluentd/Gemfile
+++ b/fluentd/Gemfile
@@ -17,6 +17,7 @@ gem 'fluent-plugin-splunk-hec', '1.3.2'
 gem 'fluent-plugin-label-router'
 gem 'libxml-ruby' #aws-sdk-core
 gem 'typhoeus' # gems that supports elasticsearch
+gem 'webrick',  '1.8.2'
 
 # gems that support fluentd
 gem 'oj'

--- a/fluentd/Gemfile.lock
+++ b/fluentd/Gemfile.lock
@@ -280,7 +280,7 @@ GEM
       activesupport
       faraday (~> 1.7)
       faraday_middleware (~> 1.1)
-    webrick (1.8.1)
+    webrick (1.8.2)
     yajl-ruby (1.4.3)
 
 PLATFORMS
@@ -319,6 +319,7 @@ DEPENDENCIES
   remote_syslog_sender!
   syslog_protocol!
   typhoeus
+  webrick (= 1.8.2)
 
 BUNDLED WITH
    2.3.7


### PR DESCRIPTION
### Description
This PR addressing to fix [cve-2024-47220](https://nvd.nist.gov/vuln/detail/cve-2024-47220) by bump WEBrick toolkit version to 1.8.2. See: https://github.com/ruby/webrick/pull/146
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-6133
- Enhancement proposal:
